### PR TITLE
Add Ollama Cloud mode with API key support

### DIFF
--- a/src/entrypoints/background/index.js
+++ b/src/entrypoints/background/index.js
@@ -9,6 +9,8 @@ export default defineBackground(() => {
         serverCacheEnabled: true,
         providerSelection: 'google',
         ollama: {
+            cloud: false,
+            apiKey: '',
             model: ''
         },
         google: {

--- a/src/entrypoints/content/ai-summarizer.js
+++ b/src/entrypoints/content/ai-summarizer.js
@@ -420,7 +420,7 @@ export async function summarizeTextWithLLM(aiProvider, modelId, apiKey, text, co
  * @param {Function} onError - Error callback (error)
  * @param {string} postTitle - Title of the post
  */
-export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathToIdMap, onSuccess, onError, postTitle) {
+export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathToIdMap, onSuccess, onError, postTitle, apiKey) {
     if (!text || !model) {
         await Logger.error('Missing required parameters for Ollama summarization');
         onError(new Error('Missing Ollama configuration'));
@@ -438,12 +438,15 @@ export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathTo
         stream: false
     };
 
+    const headers = { 'Content-Type': 'application/json' };
+    if (apiKey) {
+        headers['Authorization'] = `Bearer ${apiKey}`;
+    }
+
     sendBackgroundMessage('FETCH_API_REQUEST', {
         url: endpoint,
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
+        headers,
         body: JSON.stringify(payload),
         timeout: 180_000
     })

--- a/src/entrypoints/content/hnenhancer.js
+++ b/src/entrypoints/content/hnenhancer.js
@@ -595,7 +595,11 @@ class HNEnhancer {
                     });
                     break;
                 case 'ollama':
-                    const ollamaUrl = settings?.ollama?.url || 'http://localhost:11434';
+                    const ollamaCloud = settings?.ollama?.cloud || false;
+                    const ollamaUrl = ollamaCloud
+                        ? 'https://ollama.com'
+                        : (settings?.ollama?.url || 'http://localhost:11434');
+                    const ollamaApiKey = ollamaCloud ? settings?.ollama?.apiKey : null;
                     await summarizeUsingOllama(
                         formattedComment, model, ollamaUrl, commentPathToIdMap,
                         onSuccess,
@@ -607,7 +611,8 @@ class HNEnhancer {
                             });
                             this.attachErrorActionListeners();
                         },
-                        postTitle
+                        postTitle,
+                        ollamaApiKey
                     );
                     break;
                 case 'openai':

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -75,7 +75,8 @@
                                     <select id="active-provider" name="active-provider"
                                             class="col-start-1 row-start-1 w-48 appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:*:bg-gray-800 dark:focus-visible:outline-indigo-500">
                                         <option value="" selected>None</option>
-                                        <option value="ollama">Ollama (Local)</option>
+                                        <option value="ollama">Ollama [Local]</option>
+                                        <option value="ollama-cloud">Ollama [Cloud]</option>
                                         <option value="google">Google Gemini</option>
                                         <option value="anthropic">Anthropic</option>
                                         <option value="openai">OpenAI</option>
@@ -91,7 +92,7 @@
                         <div class="flex items-center">
                             <div aria-hidden="true" class="w-full border-t border-gray-300/70 dark:border-white/15"></div>
                             <div class="relative flex justify-center">
-                                <span class="px-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-gray-900 dark:text-gray-400 whitespace-nowrap">LOCAL AI PROVIDER (Free Option)</span>
+                                <span id="ollama-section-label" class="px-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-gray-900 dark:text-gray-400 whitespace-nowrap">LOCAL AI PROVIDER (Free Option)</span>
                             </div>
                             <div aria-hidden="true" class="w-full border-t border-gray-300/70 dark:border-white/15"></div>
                         </div>
@@ -151,19 +152,63 @@
                                         </svg>
                                     </button>
                                 </div>
-                                <p class="mt-2 ml-7 text-xs text-gray-500 dark:text-gray-400">Local models running on your machine. No API key required.</p>
+                                <p class="mt-2 ml-7 text-xs text-gray-500 dark:text-gray-400" id="ollama-subtitle">Local models running on your machine. No API key required.</p>
                                 <div class="mt-4 ml-7 space-y-4 hidden" id="ollama-body" data-provider-body="ollama">
-                                    <div>
-                                        <label for="ollama-url" class="block text-sm/6 font-medium text-gray-900 dark:text-white">Ollama Server URL</label>
-                                        <div class="mt-2">
-                                            <input type="url" name="ollama-url" id="ollama-url" value="http://localhost:11434" placeholder="http://localhost:11434"
-                                                   class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus-visible:outline-indigo-500">
+                                    <!-- Local / Cloud toggle -->
+                                    <div class="flex items-center gap-2">
+                                        <span class="text-sm font-medium text-gray-900 dark:text-white">Mode</span>
+                                        <div class="inline-flex rounded-md shadow-sm" role="group">
+                                            <button type="button" id="ollama-mode-local"
+                                                    class="px-3 py-1 text-xs font-semibold rounded-l-md border border-gray-300 bg-indigo-600 text-white dark:border-gray-600"
+                                                    data-ollama-mode="local">Local</button>
+                                            <button type="button" id="ollama-mode-cloud"
+                                                    class="px-3 py-1 text-xs font-semibold rounded-r-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-white/5 dark:text-gray-300 dark:hover:bg-white/10"
+                                                    data-ollama-mode="cloud">Cloud</button>
                                         </div>
-                                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">The base URL of your Ollama server (default: http://localhost:11434)</p>
+                                        <input type="hidden" id="ollama-cloud" name="ollama-cloud" value="false">
                                     </div>
+
+                                    <!-- Local mode fields -->
+                                    <div id="ollama-local-fields">
+                                        <div>
+                                            <label for="ollama-url" class="block text-sm/6 font-medium text-gray-900 dark:text-white">Ollama Server URL</label>
+                                            <div class="mt-2">
+                                                <input type="url" name="ollama-url" id="ollama-url" value="http://localhost:11434" placeholder="http://localhost:11434"
+                                                       class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus-visible:outline-indigo-500">
+                                            </div>
+                                            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">The base URL of your Ollama server (default: http://localhost:11434)</p>
+                                        </div>
+                                    </div>
+
+                                    <!-- Cloud mode fields -->
+                                    <div id="ollama-cloud-fields" class="hidden">
+                                        <div class="flex items-center gap-3">
+                                            <div class="relative grow">
+                                                <label for="ollama-key" class="sr-only">Enter Ollama API Key</label>
+                                                <input type="password"
+                                                       id="ollama-key"
+                                                       name="ollama-key"
+                                                       class="block w-full rounded-md bg-white px-3 py-1.5 pr-16 text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                       placeholder="Enter Ollama API Key">
+                                                <button type="button" class="absolute inset-y-0 right-2 my-auto rounded-md px-2 text-xs font-semibold text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200" data-toggle-visibility="ollama-key" aria-pressed="false">Show</button>
+                                            </div>
+                                            <details class="relative">
+                                                <summary class="list-none text-gray-400 hover:text-gray-500 cursor-pointer">
+                                                    <svg class="size-5 sm:size-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                                                        <path fill-rule="evenodd" d="M15 8A7 7 0 1 1 1 8a7 7 0 0 1 14 0Zm-6 3.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM7.293 5.293a1 1 0 1 1 .99 1.667c-.459.134-1.033.566-1.033 1.29v.25a.75.75 0 1 0 1.5 0v-.115a2.5 2 0 1 0-2.518-4.153.75.75 0 1 0 1.061 1.06Z" clip-rule="evenodd"/>
+                                                    </svg>
+                                                </summary>
+                                                <div class="absolute right-0 mt-2 w-72 bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 z-10 p-4 text-sm text-gray-600 dark:bg-gray-800 dark:text-white dark:outline-white/10 dark:focus:outline-indigo-500">
+                                                    🔑 Get your API key from <a href="https://ollama.com/settings/keys" target="_blank" class="underline">ollama.com/settings/keys</a>.
+                                                    <p class="pt-3">API key is securely stored in your browser's local storage and can sync across your devices with browser sync.</p>
+                                                </div>
+                                            </details>
+                                        </div>
+                                    </div>
+
                                     <div>
                                         <label for="ollama-model" class="block text-sm/6 font-medium text-gray-900 dark:text-white">Select Ollama Model
-                                            <span class="ml-3 inline-flex items-center rounded-md bg-yellow-50 px-2 py-1 text-xs font-medium text-yellow-800 ring-1 ring-inset ring-yellow-600/20">Make sure Ollama is running with CORS enabled</span>
+                                            <span id="ollama-cors-hint" class="ml-3 inline-flex items-center rounded-md bg-yellow-50 px-2 py-1 text-xs font-medium text-yellow-800 ring-1 ring-inset ring-yellow-600/20">Make sure Ollama is running with CORS enabled</span>
                                         </label>
                                         <div class="mt-3 grid grid-cols-1">
                                             <select id="ollama-model"

--- a/src/entrypoints/options/options.js
+++ b/src/entrypoints/options/options.js
@@ -7,6 +7,7 @@ import {Logger} from "../../lib/utils.js";
 import {sendBackgroundMessage} from "../../lib/messaging.js";
 
 const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
+const OLLAMA_CLOUD_URL = 'https://ollama.com';
 
 const OPTIONAL_HOST_PERMISSIONS = {
     openai: ['https://api.openai.com/*'],
@@ -14,6 +15,7 @@ const OPTIONAL_HOST_PERMISSIONS = {
     openrouter: ['https://openrouter.ai/*'],
     google: ['https://generativelanguage.googleapis.com/*'],
     ollama: ['http://localhost:11434/*'],
+    'ollama-cloud': ['https://ollama.com/*'],
 };
 
 const PROVIDER_INPUT_SELECTORS = {
@@ -21,8 +23,17 @@ const PROVIDER_INPUT_SELECTORS = {
     anthropic: ['#anthropic-key', '#anthropic-model'],
     openai: ['#openai-key', '#openai-model'],
     openrouter: ['#openrouter-key', '#openrouter-model'],
-    ollama: ['#ollama-url', '#ollama-model'],
+    ollama: ['#ollama-url', '#ollama-model', '#ollama-key', '#ollama-cloud'],
+    'ollama-cloud': ['#ollama-url', '#ollama-model', '#ollama-key', '#ollama-cloud'],
 };
+
+function resolveOllamaProvider(providerId) {
+    return providerId === 'ollama-cloud' ? 'ollama' : providerId;
+}
+
+function getOllamaCardId(providerId) {
+    return (providerId === 'ollama' || providerId === 'ollama-cloud') ? 'ollama' : providerId;
+}
 
 async function hasOptionalHostPermissions(origins) {
     if (!browser.permissions?.contains) {
@@ -58,6 +69,69 @@ function setOllamaModelSelectStatus(text) {
     selectElement.appendChild(option);
 }
 
+function isOllamaCloudMode() {
+    return document.getElementById('ollama-cloud').value === 'true';
+}
+
+function setOllamaMode(isCloud) {
+    const localFields = document.getElementById('ollama-local-fields');
+    const cloudFields = document.getElementById('ollama-cloud-fields');
+    const corsHint = document.getElementById('ollama-cors-hint');
+    const subtitle = document.getElementById('ollama-subtitle');
+    const hiddenInput = document.getElementById('ollama-cloud');
+    const localBtn = document.getElementById('ollama-mode-local');
+    const cloudBtn = document.getElementById('ollama-mode-cloud');
+
+    hiddenInput.value = isCloud ? 'true' : 'false';
+
+    localFields.classList.toggle('hidden', isCloud);
+    cloudFields.classList.toggle('hidden', !isCloud);
+    if (corsHint) {
+        corsHint.style.display = isCloud ? 'none' : '';
+    }
+
+    if (subtitle) {
+        subtitle.textContent = isCloud
+            ? 'Run models on Ollama\'s cloud. API key required.'
+            : 'Local models running on your machine. No API key required.';
+    }
+
+    const sectionLabel = document.getElementById('ollama-section-label');
+    if (sectionLabel) {
+        sectionLabel.textContent = isCloud
+            ? 'OLLAMA CLOUD PROVIDER (API key required)'
+            : 'LOCAL AI PROVIDER (Free Option)';
+    }
+
+    const activeClasses = 'bg-indigo-600 text-white';
+    const inactiveClasses = 'bg-white text-gray-700 hover:bg-gray-50 dark:bg-white/5 dark:text-gray-300 dark:hover:bg-white/10';
+
+    [localBtn, cloudBtn].forEach(btn => {
+        btn.className = btn.className.replace(/bg-indigo-600|text-white|bg-white|text-gray-700|hover:bg-gray-50|dark:bg-white\/5|dark:text-gray-300|dark:hover:bg-white\/10/g, '').trim();
+    });
+
+    if (isCloud) {
+        cloudBtn.classList.add(...activeClasses.split(' '));
+        localBtn.classList.add(...inactiveClasses.split(' '));
+    } else {
+        localBtn.classList.add(...activeClasses.split(' '));
+        cloudBtn.classList.add(...inactiveClasses.split(' '));
+    }
+}
+
+function getOllamaEffectiveUrl() {
+    return isOllamaCloudMode()
+        ? OLLAMA_CLOUD_URL
+        : (document.getElementById('ollama-url').value.replace(/\/+$/, '') || DEFAULT_OLLAMA_URL);
+}
+
+function getOllamaFetchHeaders() {
+    if (!isOllamaCloudMode()) return {};
+    const apiKey = document.getElementById('ollama-key').value;
+    if (!apiKey) return {};
+    return { 'Authorization': `Bearer ${apiKey}` };
+}
+
 function setPromptCustomizationState(isEnabled) {
     const systemPromptTextarea = document.getElementById('system-prompt');
     const userPromptTextarea = document.getElementById('user-prompt');
@@ -86,9 +160,11 @@ function setPromptCustomizationState(isEnabled) {
 function updateActiveProviderBadge(providerId) {
     // Allow empty string (None) as a valid selection
     const activeProvider = PROVIDER_INPUT_SELECTORS[providerId] ? providerId : '';
+    const activeCardId = getOllamaCardId(activeProvider);
 
-    Object.keys(PROVIDER_INPUT_SELECTORS).forEach((provider) => {
-        const isActive = provider === activeProvider;
+    const cardProviders = ['ollama', 'google', 'anthropic', 'openai', 'openrouter'];
+    cardProviders.forEach((provider) => {
+        const isActive = provider === activeCardId;
         const chip = document.querySelector(`[data-provider-chip="${provider}"]`);
         const card = document.querySelector(`[data-provider-card="${provider}"]`);
 
@@ -97,7 +173,6 @@ function updateActiveProviderBadge(providerId) {
             chip.classList.toggle('inline-flex', isActive);
         }
 
-        // Highlight the active provider's card
         if (card) {
             card.classList.toggle('ring-2', isActive);
             card.classList.toggle('ring-indigo-500/40', isActive);
@@ -127,7 +202,8 @@ async function toggleProviderCard(providerId) {
 
     // If expanding Ollama, fetch models
     if (providerId === 'ollama' && isCurrentlyHidden) {
-        const origins = OPTIONAL_HOST_PERMISSIONS.ollama;
+        const permKey = isOllamaCloudMode() ? 'ollama-cloud' : 'ollama';
+        const origins = OPTIONAL_HOST_PERMISSIONS[permKey];
         let granted = await hasOptionalHostPermissions(origins);
         if (!granted) {
             granted = await requestOptionalHostPermissions(origins);
@@ -142,12 +218,18 @@ async function toggleProviderCard(providerId) {
 
 // Handle active provider dropdown change
 async function handleActiveProviderChange(providerId) {
+    // Sync the Ollama mode toggle when the dropdown changes
+    if (providerId === 'ollama' || providerId === 'ollama-cloud') {
+        setOllamaMode(providerId === 'ollama-cloud');
+    }
+
     updateActiveProviderBadge(providerId);
 
     // Expand the selected provider's card if it's collapsed
-    const body = document.querySelector(`[data-provider-body="${providerId}"]`);
+    const cardId = getOllamaCardId(providerId);
+    const body = document.querySelector(`[data-provider-body="${cardId}"]`);
     if (body && body.classList.contains('hidden')) {
-        await toggleProviderCard(providerId);
+        await toggleProviderCard(cardId);
     }
 }
 
@@ -169,7 +251,8 @@ function setupKeyVisibilityToggles() {
 
 // Save settings to Browser storage
 async function saveSettings() {
-    const providerSelection = document.getElementById('active-provider').value; // Can be empty string for "None"
+    const rawProviderSelection = document.getElementById('active-provider').value; // Can be empty string for "None"
+    const providerSelection = resolveOllamaProvider(rawProviderSelection);
     // Prompt customization
     const promptCustomization = document.getElementById('prompt-customization').checked;
     const systemPrompt = document.getElementById('system-prompt').value;
@@ -178,7 +261,9 @@ async function saveSettings() {
         serverCacheEnabled: document.getElementById('hn-companion-server-enabled').checked,
         providerSelection,
         ollama: {
+            cloud: isOllamaCloudMode(),
             url: document.getElementById('ollama-url').value.replace(/\/+$/, '') || DEFAULT_OLLAMA_URL,
+            apiKey: document.getElementById('ollama-key').value,
             model: document.getElementById('ollama-model').value
         },
         google: {
@@ -221,17 +306,23 @@ async function saveSettings() {
 // Fetch Ollama models from API
 async function fetchOllamaModels() {
     try {
-        const ollamaUrl = document.getElementById('ollama-url').value.replace(/\/+$/, '') || DEFAULT_OLLAMA_URL;
+        const ollamaUrl = getOllamaEffectiveUrl();
         const selectElement = document.getElementById('ollama-model');
-        
+
         // Remember current selection before clearing
         const currentSelection = selectElement.value;
-        
-        const data = await sendBackgroundMessage('FETCH_API_REQUEST', {
+
+        const fetchOptions = {
             url: `${ollamaUrl}/api/tags`,
             method: 'GET',
-            isErrorExpected: true  // Ollama not running is expected, suppress error logs
-        });
+            isErrorExpected: true
+        };
+        const extraHeaders = getOllamaFetchHeaders();
+        if (Object.keys(extraHeaders).length > 0) {
+            fetchOptions.headers = extraHeaders;
+        }
+
+        const data = await sendBackgroundMessage('FETCH_API_REQUEST', fetchOptions);
 
         // Clear existing options
         selectElement.options.length = 0
@@ -244,21 +335,44 @@ async function fetchOllamaModels() {
             selectElement.appendChild(option);
         }
         else {
-            // Add models to select element
-            data.models.forEach(model => {
-                const option = document.createElement('option');
-                option.value = model.name;
-                option.textContent = model.name;
-                selectElement.appendChild(option);
-            });
+            const models = data.models.map(m => m.name).sort();
+
+            if (isOllamaCloudMode()) {
+                const grouped = new Map();
+                for (const name of models) {
+                    const slashIdx = name.indexOf('/');
+                    const provider = slashIdx > 0 ? name.substring(0, slashIdx) : 'ollama';
+                    const modelName = slashIdx > 0 ? name.substring(slashIdx + 1) : name;
+                    if (!grouped.has(provider)) grouped.set(provider, []);
+                    grouped.get(provider).push({ value: name, label: modelName });
+                }
+                const sortedProviders = [...grouped.keys()].sort();
+                for (const provider of sortedProviders) {
+                    const optgroup = document.createElement('optgroup');
+                    optgroup.label = provider;
+                    for (const model of grouped.get(provider)) {
+                        const option = document.createElement('option');
+                        option.value = model.value;
+                        option.textContent = model.label;
+                        optgroup.appendChild(option);
+                    }
+                    selectElement.appendChild(optgroup);
+                }
+            } else {
+                for (const name of models) {
+                    const option = document.createElement('option');
+                    option.value = name;
+                    option.textContent = name;
+                    selectElement.appendChild(option);
+                }
+            }
 
             // Restore selection: prefer current selection, fall back to saved settings
             const settings = await storage.getItem('sync:settings');
             const savedModel = settings?.ollama?.model;
             const modelToSelect = currentSelection || savedModel;
-            
+
             if (modelToSelect) {
-                // Check if the model exists in the options
                 const optionExists = Array.from(selectElement.options).some(opt => opt.value === modelToSelect);
                 if (optionExists) {
                     selectElement.value = modelToSelect;
@@ -296,13 +410,21 @@ async function loadSettings() {
             // Set provider selection in dropdown (can be empty string for "None")
             const providerDropdown = document.getElementById('active-provider');
             if (providerDropdown && settings.providerSelection !== undefined) {
-                providerDropdown.value = settings.providerSelection;
+                const dropdownValue = (settings.providerSelection === 'ollama' && settings.ollama?.cloud)
+                    ? 'ollama-cloud'
+                    : settings.providerSelection;
+                providerDropdown.value = dropdownValue;
             }
-            updateActiveProviderBadge(settings.providerSelection ?? '');
+            const badgeValue = (settings.providerSelection === 'ollama' && settings.ollama?.cloud)
+                ? 'ollama-cloud'
+                : (settings.providerSelection ?? '');
+            updateActiveProviderBadge(badgeValue);
 
             // Set Ollama settings
             if (settings.ollama) {
+                setOllamaMode(settings.ollama.cloud || false);
                 document.getElementById('ollama-url').value = settings.ollama.url || DEFAULT_OLLAMA_URL;
+                document.getElementById('ollama-key').value = settings.ollama.apiKey || '';
                 if (settings.ollama.model) {
                     document.getElementById('ollama-model').value = settings.ollama.model;
                 }
@@ -367,7 +489,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     await loadSettings();
 
     // Only attempt to load Ollama models if permission is already granted
-    if (await hasOptionalHostPermissions(OPTIONAL_HOST_PERMISSIONS.ollama)) {
+    const ollamaPermKey = isOllamaCloudMode() ? 'ollama-cloud' : 'ollama';
+    if (await hasOptionalHostPermissions(OPTIONAL_HOST_PERMISSIONS[ollamaPermKey])) {
         await fetchOllamaModels();
     } else {
         setOllamaModelSelectStatus('Expand to load models');
@@ -386,7 +509,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         const providerSelection = document.getElementById('active-provider').value; // Can be empty for "None"
 
         // 2. Request permission FIRST (MUST be first await to preserve user gesture in Firefox)
-        const origins = OPTIONAL_HOST_PERMISSIONS[providerSelection] || [];
+        const permKey = providerSelection === 'ollama-cloud' ? 'ollama-cloud' : providerSelection;
+        const origins = OPTIONAL_HOST_PERMISSIONS[permKey] || [];
         if (origins.length > 0) {
             const permissionGranted = await requestOptionalHostPermissions(origins);
             if (!permissionGranted) {
@@ -440,6 +564,36 @@ document.addEventListener('DOMContentLoaded', async () => {
     const promptCustomizationCheckbox = document.getElementById('prompt-customization');
     promptCustomizationCheckbox.addEventListener('change', (e) => {
         setPromptCustomizationState(e.target.checked);
+    });
+
+    // Ollama local/cloud mode toggle buttons — sync with active provider dropdown
+    const syncDropdownToOllamaMode = (isCloud) => {
+        const dropdown = document.getElementById('active-provider');
+        const currentIsOllama = dropdown.value === 'ollama' || dropdown.value === 'ollama-cloud';
+        if (currentIsOllama) {
+            dropdown.value = isCloud ? 'ollama-cloud' : 'ollama';
+            updateActiveProviderBadge(dropdown.value);
+        }
+    };
+
+    document.getElementById('ollama-mode-local').addEventListener('click', () => {
+        setOllamaMode(false);
+        syncDropdownToOllamaMode(false);
+        fetchOllamaModels();
+    });
+    document.getElementById('ollama-mode-cloud').addEventListener('click', async () => {
+        setOllamaMode(true);
+        syncDropdownToOllamaMode(true);
+        const origins = OPTIONAL_HOST_PERMISSIONS['ollama-cloud'];
+        let granted = await hasOptionalHostPermissions(origins);
+        if (!granted) {
+            granted = await requestOptionalHostPermissions(origins);
+        }
+        if (granted) {
+            await fetchOllamaModels();
+        } else {
+            setOllamaModelSelectStatus('Permission required to load models');
+        }
     });
 
     setupKeyVisibilityToggles();

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -22,7 +22,8 @@ export default defineConfig({
                 "https://api.anthropic.com/*",
                 "https://openrouter.ai/*",
                 "https://generativelanguage.googleapis.com/*",
-                "http://localhost:11434/*"
+                "http://localhost:11434/*",
+                "https://ollama.com/*"
             ],
             icons: {
                 16: '/icon/icon-16.png',


### PR DESCRIPTION
Hey George, Ann! 👋

Ollama recently rolled out [cloud API access](https://docs.ollama.com/cloud) — users can now run models like `glm-5.1` directly through `ollama.com` without needing a local GPU. Thought this would be a great addition since it keeps the Ollama experience familiar while opening the door to bigger models.

## What's in here

Instead of adding a whole new provider card, I kept it simple — there's now a **Local / Cloud toggle** inside the existing Ollama card:

- **Local mode** — works exactly as before (no changes to existing behavior)
- **Cloud mode** — swaps the URL field for an API key input, routes requests to `https://ollama.com/api/generate` with `Authorization: Bearer` header

A few nice touches:
- The active provider dropdown now shows **"Ollama [Local]"** and **"Ollama [Cloud]"** as separate entries
- The section header updates dynamically ("LOCAL AI PROVIDER" ↔ "OLLAMA CLOUD PROVIDER")
- Cloud model list is **grouped by provider** (e.g. google/, meta/, openai/) with alphabetical sorting within each group
- CORS hint hides in cloud mode since it's not relevant
- Dropdown and card toggle stay in sync both ways

## Files changed

- `options/index.html` — Local/Cloud toggle UI, API key field, dynamic section label
- `options/options.js` — Toggle logic, grouped model list, permission handling, save/load
- `ai-summarizer.js` — `Authorization: Bearer` header when API key is present
- `hnenhancer.js` — Reads cloud flag and routes to correct URL
- `background/index.js` — Default settings for new fields
- `wxt.config.ts` — `https://ollama.com/*` in optional_host_permissions

## Tested

- Puppeteer e2e: loaded extension, configured Ollama Cloud with API key, summarized [a live HN thread](https://news.ycombinator.com/item?id=48256953) using `glm-5.1` — summary generated in ~25s
- Verified local mode is unchanged
- Both Chrome build and Firefox build pass

## Test plan

- [ ] Load extension, open settings — Ollama card should show Local/Cloud toggle
- [ ] Switch to Cloud mode — API key field appears, URL field hides, CORS hint hides
- [ ] Select "Ollama [Cloud]" from dropdown — card toggle syncs to Cloud
- [ ] Enter API key, save, navigate to HN thread, trigger summarization
- [ ] Switch back to Local — everything reverts, existing local Ollama flow still works

Let me know what you think!