### PR TITLE
Add streaming LLM responses with progressive markdown rendering

### DIFF
--- a/src/entrypoints/background/index.js
+++ b/src/entrypoints/background/index.js
@@ -9,6 +9,8 @@ export default defineBackground(() => {
         serverCacheEnabled: true,
         providerSelection: 'google',
         ollama: {
+            cloud: false,
+            apiKey: '',
             model: ''
         },
         google: {

--- a/src/entrypoints/background/index.js
+++ b/src/entrypoints/background/index.js
@@ -1,4 +1,4 @@
-import {summarizeText} from '../../lib/llm-summarizer.js';
+import {summarizeText, streamSummarizeText} from '../../lib/llm-summarizer.js';
 import { storage } from '#imports';
 import {browser} from "wxt/browser";
 import {Logger} from "../../lib/utils.js";
@@ -103,6 +103,83 @@ export default defineBackground(() => {
             default:
                 Logger.infoSync('Unknown message type:', message.type);
         }
+    });
+
+    // Handle streaming connections via ports
+    browser.runtime.onConnect.addListener((port) => {
+        if (port.name !== 'HN_STREAM') return;
+
+        let abortController = null;
+
+        port.onDisconnect.addListener(() => {
+            if (abortController) abortController.abort();
+        });
+
+        port.onMessage.addListener(async (message) => {
+            const safeSend = (msg) => {
+                try { port.postMessage(msg); } catch (_) { /* port disconnected */ }
+            };
+
+            if (message.type === 'HN_STREAM_SUMMARIZE') {
+                abortController = new AbortController();
+                await streamSummarizeText(
+                    message.data,
+                    (delta) => safeSend({ type: 'chunk', delta }),
+                    (fullText) => safeSend({ type: 'done', text: fullText }),
+                    (error) => safeSend({ type: 'error', error: error.toString() }),
+                    abortController.signal
+                );
+            } else if (message.type === 'HN_STREAM_OLLAMA') {
+                abortController = new AbortController();
+                try {
+                    const { url, method, headers, body, timeout } = message.data;
+                    const id = setTimeout(() => abortController.abort(), timeout || 180_000);
+                    const response = await fetch(url, {
+                        method, headers, body,
+                        signal: abortController.signal
+                    });
+                    clearTimeout(id);
+
+                    if (!response.ok) {
+                        const errorText = await response.text();
+                        safeSend({ type: 'error', error: `API Error: HTTP ${response.status} ${errorText}` });
+                        return;
+                    }
+
+                    const reader = response.body.getReader();
+                    const decoder = new TextDecoder();
+                    let fullText = '';
+
+                    while (true) {
+                        const { done, value } = await reader.read();
+                        if (done) break;
+                        if (abortController.signal.aborted) break;
+
+                        const chunk = decoder.decode(value, { stream: true });
+                        for (const line of chunk.split('\n')) {
+                            if (!line.trim()) continue;
+                            try {
+                                const parsed = JSON.parse(line);
+                                if (parsed.response) {
+                                    fullText += parsed.response;
+                                    safeSend({ type: 'chunk', delta: parsed.response });
+                                }
+                                if (parsed.done) {
+                                    safeSend({ type: 'done', text: fullText });
+                                    return;
+                                }
+                            } catch (_) { /* skip malformed lines */ }
+                        }
+                    }
+
+                    safeSend({ type: 'done', text: fullText });
+                } catch (error) {
+                    if (!abortController.signal.aborted) {
+                        safeSend({ type: 'error', error: error.toString() });
+                    }
+                }
+            }
+        });
     });
 
     // Handle async message and send response

--- a/src/entrypoints/content/ai-summarizer.js
+++ b/src/entrypoints/content/ai-summarizer.js
@@ -420,7 +420,7 @@ export async function summarizeTextWithLLM(aiProvider, modelId, apiKey, text, co
  * @param {Function} onError - Error callback (error)
  * @param {string} postTitle - Title of the post
  */
-export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathToIdMap, onSuccess, onError, postTitle) {
+export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathToIdMap, onSuccess, onError, postTitle, apiKey) {
     if (!text || !model) {
         await Logger.error('Missing required parameters for Ollama summarization');
         onError(new Error('Missing Ollama configuration'));
@@ -438,12 +438,15 @@ export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathTo
         stream: false
     };
 
+    const headers = { 'Content-Type': 'application/json' };
+    if (apiKey) {
+        headers['Authorization'] = `Bearer ${apiKey}`;
+    }
+
     sendBackgroundMessage('FETCH_API_REQUEST', {
         url: endpoint,
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
+        headers,
         body: JSON.stringify(payload),
         timeout: 180_000
     })

--- a/src/entrypoints/content/ai-summarizer.js
+++ b/src/entrypoints/content/ai-summarizer.js
@@ -449,8 +449,7 @@ export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathTo
         headers['Authorization'] = `Bearer ${apiKey}`;
     }
 
-    // Ollama Cloud: stream via port
-    if (apiKey && onChunk) {
+    if (onChunk) {
         const payload = { model, system: systemMessage, prompt: userMessage, stream: true };
         sendStreamingMessage('HN_STREAM_OLLAMA', {
             url: endpoint, method: 'POST', headers,
@@ -462,29 +461,26 @@ export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathTo
             }
             onSuccess(summary, data.duration, commentPathToIdMap);
         }).catch(error => {
-            Logger.errorSync('Ollama Cloud streaming failed:', error.message);
+            Logger.errorSync('Ollama streaming failed:', error.message);
             onError(error);
         });
         return;
     }
 
-    // Ollama Local: single-shot fetch
     const payload = { model, system: systemMessage, prompt: userMessage, stream: false };
-
     sendBackgroundMessage('FETCH_API_REQUEST', {
         url: endpoint,
         method: 'POST',
         headers,
         body: JSON.stringify(payload),
         timeout: 180_000
-    })
-        .then(data => {
-            const summary = data.response;
-            if (!summary) {
-                throw new Error('No summary generated from API response');
-            }
-            onSuccess(summary, data.duration, commentPathToIdMap);
-        }).catch(error => {
+    }).then(data => {
+        const summary = data.response;
+        if (!summary) {
+            throw new Error('No summary generated from API response');
+        }
+        onSuccess(summary, data.duration, commentPathToIdMap);
+    }).catch(error => {
         Logger.errorSync('Error in Ollama summarization:', error);
         onError(error);
     });

--- a/src/entrypoints/content/ai-summarizer.js
+++ b/src/entrypoints/content/ai-summarizer.js
@@ -496,21 +496,14 @@ export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathTo
  * @returns {DocumentFragment|string}
  */
 export function createOllamaErrorMessage(error) {
-    // For 403 errors, show detailed CORS instructions using markdown
     if (error.message?.includes('403')) {
-        const errorMarkdown = `Ollama blocked the request (likely a CORS or server configuration issue).
-
-**To fix:**
-
-1. Restart Ollama with CORS enabled:
-   \`\`\`
-   OLLAMA_ORIGINS="chrome-extension://*,moz-extension://*" ollama serve
-   \`\`\`
-
-2. Verify the Ollama URL in the extension settings and ensure Ollama is running.
-
-*If the problem continues, check Ollama logs or the extension settings for more details.*`;
-        return createSummaryFragment(errorMarkdown, new Map());
+        return createErrorElement({
+            type: 'network',
+            title: 'Ollama Blocked the Request',
+            description: 'Ollama rejected the request because the browser extension origin is not allowed. You need to start Ollama with CORS enabled.',
+            action: { label: 'Open Settings', id: 'error-open-settings' },
+            hint: 'Run: <code>OLLAMA_ORIGINS="chrome-extension://*,moz-extension://*" ollama serve</code><br>See the setup guide in extension settings for Windows instructions.'
+        });
     }
 
     // For network errors, use the styled error element

--- a/src/entrypoints/content/ai-summarizer.js
+++ b/src/entrypoints/content/ai-summarizer.js
@@ -5,7 +5,7 @@
 
 import {storage} from '#imports';
 import {Logger} from "../../lib/utils.js";
-import {sendBackgroundMessage} from "../../lib/messaging.js";
+import {sendBackgroundMessage, sendStreamingMessage} from "../../lib/messaging.js";
 import {AI_SYSTEM_PROMPT, AI_USER_PROMPT_TEMPLATE} from './constants.js';
 // Import generic utilities from lib
 import {buildFragment, createStrong, createInternalLink, createExternalLink} from '../../lib/dom-utils.js';
@@ -366,7 +366,7 @@ export function formatSummaryError(error) {
  * @param {Function} onError - Error callback (error)
  * @param {string} postTitle - Title of the post
  */
-export async function summarizeTextWithLLM(aiProvider, modelId, apiKey, text, commentPathToIdMap, onSuccess, onError, postTitle) {
+export async function summarizeTextWithLLM(aiProvider, modelId, apiKey, text, commentPathToIdMap, onSuccess, onError, postTitle, onChunk) {
     if (!text || !aiProvider || !modelId || !apiKey) {
         await Logger.error('Missing required parameters for AI summarization');
         onError(new Error('Missing AI configuration'));
@@ -398,16 +398,29 @@ export async function summarizeTextWithLLM(aiProvider, modelId, apiKey, text, co
         parameters,
     };
 
-    sendBackgroundMessage('HN_SUMMARIZE', llmInput).then(data => {
-        const summary = data?.summary;
-        if (!summary) {
-            throw new Error('Empty summary returned from background message HN_SUMMARIZE. data: ' + JSON.stringify(data));
-        }
-        onSuccess(summary, data.duration, commentPathToIdMap);
-    }).catch(error => {
-        Logger.errorSync('LLM summarization failed in summarizeTextWithLLM(). Error:', error.message);
-        onError(error);
-    });
+    if (onChunk) {
+        sendStreamingMessage('HN_STREAM_SUMMARIZE', llmInput, onChunk).then(data => {
+            const summary = data?.summary;
+            if (!summary) {
+                throw new Error('Empty summary returned from streaming');
+            }
+            onSuccess(summary, data.duration, commentPathToIdMap);
+        }).catch(error => {
+            Logger.errorSync('LLM streaming failed:', error.message);
+            onError(error);
+        });
+    } else {
+        sendBackgroundMessage('HN_SUMMARIZE', llmInput).then(data => {
+            const summary = data?.summary;
+            if (!summary) {
+                throw new Error('Empty summary returned from background message HN_SUMMARIZE. data: ' + JSON.stringify(data));
+            }
+            onSuccess(summary, data.duration, commentPathToIdMap);
+        }).catch(error => {
+            Logger.errorSync('LLM summarization failed in summarizeTextWithLLM(). Error:', error.message);
+            onError(error);
+        });
+    }
 }
 
 /**
@@ -420,7 +433,7 @@ export async function summarizeTextWithLLM(aiProvider, modelId, apiKey, text, co
  * @param {Function} onError - Error callback (error)
  * @param {string} postTitle - Title of the post
  */
-export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathToIdMap, onSuccess, onError, postTitle, apiKey) {
+export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathToIdMap, onSuccess, onError, postTitle, apiKey, onChunk) {
     if (!text || !model) {
         await Logger.error('Missing required parameters for Ollama summarization');
         onError(new Error('Missing Ollama configuration'));
@@ -431,17 +444,32 @@ export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathTo
     const systemMessage = await getSystemMessage();
     const userMessage = await getUserMessage(postTitle, text);
 
-    const payload = {
-        model: model,
-        system: systemMessage,
-        prompt: userMessage,
-        stream: false
-    };
-
     const headers = { 'Content-Type': 'application/json' };
     if (apiKey) {
         headers['Authorization'] = `Bearer ${apiKey}`;
     }
+
+    // Ollama Cloud: stream via port
+    if (apiKey && onChunk) {
+        const payload = { model, system: systemMessage, prompt: userMessage, stream: true };
+        sendStreamingMessage('HN_STREAM_OLLAMA', {
+            url: endpoint, method: 'POST', headers,
+            body: JSON.stringify(payload), timeout: 180_000
+        }, onChunk).then(data => {
+            const summary = data?.summary;
+            if (!summary) {
+                throw new Error('No summary generated from streaming Ollama response');
+            }
+            onSuccess(summary, data.duration, commentPathToIdMap);
+        }).catch(error => {
+            Logger.errorSync('Ollama Cloud streaming failed:', error.message);
+            onError(error);
+        });
+        return;
+    }
+
+    // Ollama Local: single-shot fetch
+    const payload = { model, system: systemMessage, prompt: userMessage, stream: false };
 
     sendBackgroundMessage('FETCH_API_REQUEST', {
         url: endpoint,

--- a/src/entrypoints/content/hnenhancer.js
+++ b/src/entrypoints/content/hnenhancer.js
@@ -628,7 +628,7 @@ class HNEnhancer {
                         },
                         postTitle,
                         ollamaApiKey,
-                        ollamaCloud ? onChunk : undefined
+                        onChunk
                     );
                     break;
                 case 'openai':

--- a/src/entrypoints/content/hnenhancer.js
+++ b/src/entrypoints/content/hnenhancer.js
@@ -595,7 +595,11 @@ class HNEnhancer {
                     });
                     break;
                 case 'ollama':
-                    const ollamaUrl = settings?.ollama?.url || 'http://localhost:11434';
+                    const ollamaCloud = settings?.ollama?.cloud || false;
+                    const ollamaUrl = ollamaCloud
+                        ? 'https://ollama.com'
+                        : (settings?.ollama?.url || 'http://localhost:11434');
+                    const ollamaApiKey = ollamaCloud ? settings?.ollama?.apiKey : null;
                     await summarizeUsingOllama(
                         formattedComment, model, ollamaUrl, commentPathToIdMap,
                         onSuccess,
@@ -607,7 +611,8 @@ class HNEnhancer {
                             });
                             this.attachErrorActionListeners();
                         },
-                        postTitle
+                        postTitle,
+                        ollamaApiKey
                     );
                     break;
                 case 'openai':

--- a/src/entrypoints/content/hnenhancer.js
+++ b/src/entrypoints/content/hnenhancer.js
@@ -578,13 +578,27 @@ class HNEnhancer {
             formattedComment = stripAnchors(formattedComment);
             const postTitle = this.getHNPostTitle();
 
+            let streamingStarted = false;
+            const onChunk = (delta) => {
+                if (!streamingStarted) {
+                    streamingStarted = true;
+                    this.summaryPanel.updateMetadataRow({
+                        state: 'streaming',
+                        provider: `${aiProvider}/${model || ''}`
+                    });
+                }
+                this.summaryPanel.appendStreamingText(delta);
+            };
+
             const onSuccess = (summary, duration, pathMap) => {
+                this.summaryPanel.finishStreaming();
                 this.showSummaryInPanel(summary, false, duration, pathMap, itemId).catch(error => {
                     Logger.errorSync('Error showing summary:', error);
                 });
             };
 
             const onError = (error) => {
+                this.summaryPanel.finishStreaming();
                 this.handleSummaryError(error);
             };
 
@@ -604,6 +618,7 @@ class HNEnhancer {
                         formattedComment, model, ollamaUrl, commentPathToIdMap,
                         onSuccess,
                         (error) => {
+                            this.summaryPanel.finishStreaming();
                             const errorFragment = createOllamaErrorMessage(error);
                             this.summaryPanel.updateContent({
                                 text: errorFragment,
@@ -612,7 +627,8 @@ class HNEnhancer {
                             this.attachErrorActionListeners();
                         },
                         postTitle,
-                        ollamaApiKey
+                        ollamaApiKey,
+                        ollamaCloud ? onChunk : undefined
                     );
                     break;
                 case 'openai':
@@ -622,7 +638,8 @@ class HNEnhancer {
                     const apiKey = settings?.[aiProvider]?.apiKey;
                     await summarizeTextWithLLM(
                         aiProvider, model, apiKey, formattedComment, commentPathToIdMap,
-                        onSuccess, onError, postTitle
+                        onSuccess, onError, postTitle,
+                        onChunk
                     );
                     break;
                 default:

--- a/src/entrypoints/content/styles.css
+++ b/src/entrypoints/content/styles.css
@@ -505,6 +505,17 @@
     color: #4a7c4a;
 }
 
+.summary-metadata-chip-streaming {
+    background-color: #e0e8f0;
+    color: #3a6a8a;
+    animation: streaming-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes streaming-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+}
+
 .summary-metadata-provider-link,
 .summary-metadata-provider-link:link,
 .summary-metadata-provider-link:visited {

--- a/src/entrypoints/content/summary-panel.js
+++ b/src/entrypoints/content/summary-panel.js
@@ -1,6 +1,8 @@
 import {storage} from '#imports';
 import {browser} from 'wxt/browser';
 import {qualifyCommentLinks} from './comment-processor.js';
+import {marked} from 'marked';
+import {sanitizeHtmlToFragment, enforceSafeLinks} from '../../lib/sanitize.js';
 
 // SVG Icon constants
 const ICONS = {
@@ -739,6 +741,8 @@ class SummaryPanel {
             this.renderCachedMetadata(metadataInfo, metadata);
         } else if (metadata.state === 'generated') {
             this.renderGeneratedMetadata(metadataInfo, metadata);
+        } else if (metadata.state === 'streaming') {
+            this.renderStreamingMetadata(metadataInfo, metadata);
         }
     }
 
@@ -809,6 +813,71 @@ class SummaryPanel {
                 browser.runtime.sendMessage({ type: 'HN_SHOW_OPTIONS', data: {} });
             });
             container.appendChild(providerLink);
+        }
+    }
+    appendStreamingText(delta) {
+        if (!this.panel) return;
+        const textElement = this.panel.querySelector('.summary-text');
+        if (!textElement) return;
+
+        if (!this._isStreaming) {
+            this._isStreaming = true;
+            this._streamBuffer = '';
+            textElement.replaceChildren();
+        }
+
+        this._streamBuffer += delta;
+
+        if (!this._renderTimer) {
+            this._renderTimer = setTimeout(() => {
+                this._renderStreamedMarkdown(textElement);
+                this._renderTimer = null;
+            }, 150);
+        }
+    }
+
+    _renderStreamedMarkdown(textElement) {
+        if (!this._streamBuffer) return;
+        try {
+            const html = marked.parse(this._streamBuffer);
+            const fragment = sanitizeHtmlToFragment(html);
+            enforceSafeLinks(fragment);
+            this.setElementContent(textElement, fragment);
+        } catch (_) {
+            textElement.textContent = this._streamBuffer;
+        }
+
+        const content = this.panel?.querySelector('.summary-panel-content');
+        if (content) {
+            content.scrollTop = content.scrollHeight;
+        }
+    }
+
+    finishStreaming() {
+        if (this._renderTimer) {
+            clearTimeout(this._renderTimer);
+            this._renderTimer = null;
+        }
+        this._isStreaming = false;
+        this._streamBuffer = '';
+    }
+
+    renderStreamingMetadata(container, metadata) {
+        const chip = document.createElement('span');
+        chip.className = 'summary-metadata-chip summary-metadata-chip-streaming';
+        chip.textContent = 'Streaming';
+        container.appendChild(chip);
+
+        if (metadata.provider) {
+            const sep = document.createElement('span');
+            sep.className = 'summary-metadata-separator summary-metadata-provider-separator';
+            sep.textContent = ' | ';
+            container.appendChild(sep);
+
+            const providerSpan = document.createElement('span');
+            providerSpan.className = 'summary-metadata-primary summary-metadata-provider';
+            providerSpan.textContent = metadata.provider;
+            container.appendChild(providerSpan);
         }
     }
 }

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -75,7 +75,8 @@
                                     <select id="active-provider" name="active-provider"
                                             class="col-start-1 row-start-1 w-48 appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:*:bg-gray-800 dark:focus-visible:outline-indigo-500">
                                         <option value="" selected>None</option>
-                                        <option value="ollama">Ollama (Local)</option>
+                                        <option value="ollama">Ollama [Local]</option>
+                                        <option value="ollama-cloud">Ollama [Cloud]</option>
                                         <option value="google">Google Gemini</option>
                                         <option value="anthropic">Anthropic</option>
                                         <option value="openai">OpenAI</option>
@@ -91,7 +92,7 @@
                         <div class="flex items-center">
                             <div aria-hidden="true" class="w-full border-t border-gray-300/70 dark:border-white/15"></div>
                             <div class="relative flex justify-center">
-                                <span class="px-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-gray-900 dark:text-gray-400 whitespace-nowrap">LOCAL AI PROVIDER (Free Option)</span>
+                                <span id="ollama-section-label" class="px-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-gray-900 dark:text-gray-400 whitespace-nowrap">LOCAL AI PROVIDER (Free Option)</span>
                             </div>
                             <div aria-hidden="true" class="w-full border-t border-gray-300/70 dark:border-white/15"></div>
                         </div>
@@ -151,19 +152,63 @@
                                         </svg>
                                     </button>
                                 </div>
-                                <p class="mt-2 ml-7 text-xs text-gray-500 dark:text-gray-400">Local models running on your machine. No API key required.</p>
+                                <p class="mt-2 ml-7 text-xs text-gray-500 dark:text-gray-400" id="ollama-subtitle">Local models running on your machine. No API key required.</p>
                                 <div class="mt-4 ml-7 space-y-4 hidden" id="ollama-body" data-provider-body="ollama">
-                                    <div>
-                                        <label for="ollama-url" class="block text-sm/6 font-medium text-gray-900 dark:text-white">Ollama Server URL</label>
-                                        <div class="mt-2">
-                                            <input type="url" name="ollama-url" id="ollama-url" value="http://localhost:11434" placeholder="http://localhost:11434"
-                                                   class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus-visible:outline-indigo-500">
+                                    <!-- Local / Cloud toggle -->
+                                    <div class="flex items-center gap-2">
+                                        <span class="text-sm font-medium text-gray-900 dark:text-white">Mode</span>
+                                        <div class="inline-flex rounded-md shadow-sm" role="group">
+                                            <button type="button" id="ollama-mode-local"
+                                                    class="px-3 py-1 text-xs font-semibold rounded-l-md border border-gray-300 bg-indigo-600 text-white dark:border-gray-600"
+                                                    data-ollama-mode="local">Local</button>
+                                            <button type="button" id="ollama-mode-cloud"
+                                                    class="px-3 py-1 text-xs font-semibold rounded-r-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-white/5 dark:text-gray-300 dark:hover:bg-white/10"
+                                                    data-ollama-mode="cloud">Cloud</button>
                                         </div>
-                                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">The base URL of your Ollama server (default: http://localhost:11434)</p>
+                                        <input type="hidden" id="ollama-cloud" name="ollama-cloud" value="false">
                                     </div>
+
+                                    <!-- Local mode fields -->
+                                    <div id="ollama-local-fields">
+                                        <div>
+                                            <label for="ollama-url" class="block text-sm/6 font-medium text-gray-900 dark:text-white">Ollama Server URL</label>
+                                            <div class="mt-2">
+                                                <input type="url" name="ollama-url" id="ollama-url" value="http://localhost:11434" placeholder="http://localhost:11434"
+                                                       class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus-visible:outline-indigo-500">
+                                            </div>
+                                            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">The base URL of your Ollama server (default: http://localhost:11434)</p>
+                                        </div>
+                                    </div>
+
+                                    <!-- Cloud mode fields -->
+                                    <div id="ollama-cloud-fields" class="hidden">
+                                        <div class="flex items-center gap-3">
+                                            <div class="relative grow">
+                                                <label for="ollama-key" class="sr-only">Enter Ollama API Key</label>
+                                                <input type="password"
+                                                       id="ollama-key"
+                                                       name="ollama-key"
+                                                       class="block w-full rounded-md bg-white px-3 py-1.5 pr-16 text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                       placeholder="Enter Ollama API Key">
+                                                <button type="button" class="absolute inset-y-0 right-2 my-auto rounded-md px-2 text-xs font-semibold text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200" data-toggle-visibility="ollama-key" aria-pressed="false">Show</button>
+                                            </div>
+                                            <details class="relative">
+                                                <summary class="list-none text-gray-400 hover:text-gray-500 cursor-pointer">
+                                                    <svg class="size-5 sm:size-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                                                        <path fill-rule="evenodd" d="M15 8A7 7 0 1 1 1 8a7 7 0 0 1 14 0Zm-6 3.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM7.293 5.293a1 1 0 1 1 .99 1.667c-.459.134-1.033.566-1.033 1.29v.25a.75.75 0 1 0 1.5 0v-.115a2.5 2 0 1 0-2.518-4.153.75.75 0 1 0 1.061 1.06Z" clip-rule="evenodd"/>
+                                                    </svg>
+                                                </summary>
+                                                <div class="absolute right-0 mt-2 w-72 bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 z-10 p-4 text-sm text-gray-600 dark:bg-gray-800 dark:text-white dark:outline-white/10 dark:focus:outline-indigo-500">
+                                                    🔑 Get your API key from <a href="https://ollama.com/settings/keys" target="_blank" class="underline">ollama.com/settings/keys</a>.
+                                                    <p class="pt-3">API key is securely stored in your browser's local storage and can sync across your devices with browser sync.</p>
+                                                </div>
+                                            </details>
+                                        </div>
+                                    </div>
+
                                     <div>
                                         <label for="ollama-model" class="block text-sm/6 font-medium text-gray-900 dark:text-white">Select Ollama Model
-                                            <span class="ml-3 inline-flex items-center rounded-md bg-yellow-50 px-2 py-1 text-xs font-medium text-yellow-800 ring-1 ring-inset ring-yellow-600/20">Make sure Ollama is running with CORS enabled</span>
+                                            <span id="ollama-cors-hint" class="ml-3 inline-flex items-center rounded-md bg-yellow-50 px-2 py-1 text-xs font-medium text-yellow-800 ring-1 ring-inset ring-yellow-600/20">Make sure Ollama is running with CORS enabled</span>
                                         </label>
                                         <div class="mt-3 grid grid-cols-1">
                                             <select id="ollama-model"

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -121,7 +121,7 @@
                                                     <li>Make sure Ollama is running to see the list of available models in the dropdown</li>
                                                     <li>Enable CORS for the extension:
                                                         <div class="mt-2 p-2 bg-gray-200 rounded font-mono text-xs dark:bg-gray-900 dark:text-white">
-                                                            <p class="mb-1">On Mac (run on terminal):</p>
+                                                            <p class="mb-1">On Mac / Linux (run in terminal):</p>
                                                             <code class="bg-gray-100 px-2 py-1 rounded block overflow-x-auto dark:bg-gray-800 dark:text-white">
                                                                 OLLAMA_ORIGINS="chrome-extension://*,moz-extension://*" ollama serve
                                                             </code>

--- a/src/entrypoints/options/options.js
+++ b/src/entrypoints/options/options.js
@@ -14,7 +14,7 @@ const OPTIONAL_HOST_PERMISSIONS = {
     anthropic: ['https://api.anthropic.com/*'],
     openrouter: ['https://openrouter.ai/*'],
     google: ['https://generativelanguage.googleapis.com/*'],
-    ollama: ['http://localhost:11434/*'],
+    ollama: [],
     'ollama-cloud': ['https://ollama.com/*'],
 };
 

--- a/src/entrypoints/options/options.js
+++ b/src/entrypoints/options/options.js
@@ -36,6 +36,9 @@ function getOllamaCardId(providerId) {
 }
 
 async function hasOptionalHostPermissions(origins) {
+    if (!origins || origins.length === 0) {
+        return true;
+    }
     if (!browser.permissions?.contains) {
         return true;
     }

--- a/src/entrypoints/options/options.js
+++ b/src/entrypoints/options/options.js
@@ -14,7 +14,7 @@ const OPTIONAL_HOST_PERMISSIONS = {
     anthropic: ['https://api.anthropic.com/*'],
     openrouter: ['https://openrouter.ai/*'],
     google: ['https://generativelanguage.googleapis.com/*'],
-    ollama: [],
+    ollama: ['http://localhost:11434/*'],
     'ollama-cloud': ['https://ollama.com/*'],
 };
 

--- a/src/entrypoints/options/options.js
+++ b/src/entrypoints/options/options.js
@@ -383,16 +383,15 @@ async function fetchOllamaModels() {
             }
         }
     } catch (error) {
-        // Ollama not running is expected - user may not have started it yet
-        // Only log at debug level to avoid noise
-        await Logger.debug('Could not fetch Ollama models (Ollama may not be running):', error.message);
-        // Handle error by adding a helpful status option
+        await Logger.debug('Could not fetch Ollama models:', error.message);
         const selectElement = document.getElementById('ollama-model');
-        selectElement.options.length = 0
+        selectElement.options.length = 0;
 
         const option = document.createElement('option');
         option.value = '';
-        option.textContent = 'Ollama not running';
+        option.textContent = error.message?.includes('403')
+            ? 'CORS blocked — see setup guide above'
+            : 'Ollama not running';
         selectElement.appendChild(option);
     }
 }

--- a/src/entrypoints/options/options.js
+++ b/src/entrypoints/options/options.js
@@ -7,6 +7,7 @@ import {Logger} from "../../lib/utils.js";
 import {sendBackgroundMessage} from "../../lib/messaging.js";
 
 const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
+const OLLAMA_CLOUD_URL = 'https://ollama.com';
 
 const OPTIONAL_HOST_PERMISSIONS = {
     openai: ['https://api.openai.com/*'],
@@ -14,6 +15,7 @@ const OPTIONAL_HOST_PERMISSIONS = {
     openrouter: ['https://openrouter.ai/*'],
     google: ['https://generativelanguage.googleapis.com/*'],
     ollama: ['http://localhost:11434/*'],
+    'ollama-cloud': ['https://ollama.com/*'],
 };
 
 const PROVIDER_INPUT_SELECTORS = {
@@ -21,8 +23,17 @@ const PROVIDER_INPUT_SELECTORS = {
     anthropic: ['#anthropic-key', '#anthropic-model'],
     openai: ['#openai-key', '#openai-model'],
     openrouter: ['#openrouter-key', '#openrouter-model'],
-    ollama: ['#ollama-url', '#ollama-model'],
+    ollama: ['#ollama-url', '#ollama-model', '#ollama-key', '#ollama-cloud'],
+    'ollama-cloud': ['#ollama-url', '#ollama-model', '#ollama-key', '#ollama-cloud'],
 };
+
+function resolveOllamaProvider(providerId) {
+    return providerId === 'ollama-cloud' ? 'ollama' : providerId;
+}
+
+function getOllamaCardId(providerId) {
+    return (providerId === 'ollama' || providerId === 'ollama-cloud') ? 'ollama' : providerId;
+}
 
 async function hasOptionalHostPermissions(origins) {
     if (!browser.permissions?.contains) {
@@ -58,6 +69,69 @@ function setOllamaModelSelectStatus(text) {
     selectElement.appendChild(option);
 }
 
+function isOllamaCloudMode() {
+    return document.getElementById('ollama-cloud').value === 'true';
+}
+
+function setOllamaMode(isCloud) {
+    const localFields = document.getElementById('ollama-local-fields');
+    const cloudFields = document.getElementById('ollama-cloud-fields');
+    const corsHint = document.getElementById('ollama-cors-hint');
+    const subtitle = document.getElementById('ollama-subtitle');
+    const hiddenInput = document.getElementById('ollama-cloud');
+    const localBtn = document.getElementById('ollama-mode-local');
+    const cloudBtn = document.getElementById('ollama-mode-cloud');
+
+    hiddenInput.value = isCloud ? 'true' : 'false';
+
+    localFields.classList.toggle('hidden', isCloud);
+    cloudFields.classList.toggle('hidden', !isCloud);
+    if (corsHint) {
+        corsHint.style.display = isCloud ? 'none' : '';
+    }
+
+    if (subtitle) {
+        subtitle.textContent = isCloud
+            ? 'Run models on Ollama\'s cloud. API key required.'
+            : 'Local models running on your machine. No API key required.';
+    }
+
+    const sectionLabel = document.getElementById('ollama-section-label');
+    if (sectionLabel) {
+        sectionLabel.textContent = isCloud
+            ? 'OLLAMA CLOUD PROVIDER (API key required)'
+            : 'LOCAL AI PROVIDER (Free Option)';
+    }
+
+    const activeClasses = 'bg-indigo-600 text-white';
+    const inactiveClasses = 'bg-white text-gray-700 hover:bg-gray-50 dark:bg-white/5 dark:text-gray-300 dark:hover:bg-white/10';
+
+    [localBtn, cloudBtn].forEach(btn => {
+        btn.className = btn.className.replace(/bg-indigo-600|text-white|bg-white|text-gray-700|hover:bg-gray-50|dark:bg-white\/5|dark:text-gray-300|dark:hover:bg-white\/10/g, '').trim();
+    });
+
+    if (isCloud) {
+        cloudBtn.classList.add(...activeClasses.split(' '));
+        localBtn.classList.add(...inactiveClasses.split(' '));
+    } else {
+        localBtn.classList.add(...activeClasses.split(' '));
+        cloudBtn.classList.add(...inactiveClasses.split(' '));
+    }
+}
+
+function getOllamaEffectiveUrl() {
+    return isOllamaCloudMode()
+        ? OLLAMA_CLOUD_URL
+        : (document.getElementById('ollama-url').value.replace(/\/+$/, '') || DEFAULT_OLLAMA_URL);
+}
+
+function getOllamaFetchHeaders() {
+    if (!isOllamaCloudMode()) return {};
+    const apiKey = document.getElementById('ollama-key').value;
+    if (!apiKey) return {};
+    return { 'Authorization': `Bearer ${apiKey}` };
+}
+
 function setPromptCustomizationState(isEnabled) {
     const systemPromptTextarea = document.getElementById('system-prompt');
     const userPromptTextarea = document.getElementById('user-prompt');
@@ -86,9 +160,11 @@ function setPromptCustomizationState(isEnabled) {
 function updateActiveProviderBadge(providerId) {
     // Allow empty string (None) as a valid selection
     const activeProvider = PROVIDER_INPUT_SELECTORS[providerId] ? providerId : '';
+    const activeCardId = getOllamaCardId(activeProvider);
 
-    Object.keys(PROVIDER_INPUT_SELECTORS).forEach((provider) => {
-        const isActive = provider === activeProvider;
+    const cardProviders = ['ollama', 'google', 'anthropic', 'openai', 'openrouter'];
+    cardProviders.forEach((provider) => {
+        const isActive = provider === activeCardId;
         const chip = document.querySelector(`[data-provider-chip="${provider}"]`);
         const card = document.querySelector(`[data-provider-card="${provider}"]`);
 
@@ -97,7 +173,6 @@ function updateActiveProviderBadge(providerId) {
             chip.classList.toggle('inline-flex', isActive);
         }
 
-        // Highlight the active provider's card
         if (card) {
             card.classList.toggle('ring-2', isActive);
             card.classList.toggle('ring-indigo-500/40', isActive);
@@ -127,7 +202,8 @@ async function toggleProviderCard(providerId) {
 
     // If expanding Ollama, fetch models
     if (providerId === 'ollama' && isCurrentlyHidden) {
-        const origins = OPTIONAL_HOST_PERMISSIONS.ollama;
+        const permKey = isOllamaCloudMode() ? 'ollama-cloud' : 'ollama';
+        const origins = OPTIONAL_HOST_PERMISSIONS[permKey];
         let granted = await hasOptionalHostPermissions(origins);
         if (!granted) {
             granted = await requestOptionalHostPermissions(origins);
@@ -142,12 +218,18 @@ async function toggleProviderCard(providerId) {
 
 // Handle active provider dropdown change
 async function handleActiveProviderChange(providerId) {
+    // Sync the Ollama mode toggle when the dropdown changes
+    if (providerId === 'ollama' || providerId === 'ollama-cloud') {
+        setOllamaMode(providerId === 'ollama-cloud');
+    }
+
     updateActiveProviderBadge(providerId);
 
     // Expand the selected provider's card if it's collapsed
-    const body = document.querySelector(`[data-provider-body="${providerId}"]`);
+    const cardId = getOllamaCardId(providerId);
+    const body = document.querySelector(`[data-provider-body="${cardId}"]`);
     if (body && body.classList.contains('hidden')) {
-        await toggleProviderCard(providerId);
+        await toggleProviderCard(cardId);
     }
 }
 
@@ -169,7 +251,8 @@ function setupKeyVisibilityToggles() {
 
 // Save settings to Browser storage
 async function saveSettings() {
-    const providerSelection = document.getElementById('active-provider').value; // Can be empty string for "None"
+    const rawProviderSelection = document.getElementById('active-provider').value; // Can be empty string for "None"
+    const providerSelection = resolveOllamaProvider(rawProviderSelection);
     // Prompt customization
     const promptCustomization = document.getElementById('prompt-customization').checked;
     const systemPrompt = document.getElementById('system-prompt').value;
@@ -178,7 +261,9 @@ async function saveSettings() {
         serverCacheEnabled: document.getElementById('hn-companion-server-enabled').checked,
         providerSelection,
         ollama: {
+            cloud: isOllamaCloudMode(),
             url: document.getElementById('ollama-url').value.replace(/\/+$/, '') || DEFAULT_OLLAMA_URL,
+            apiKey: document.getElementById('ollama-key').value,
             model: document.getElementById('ollama-model').value
         },
         google: {
@@ -221,17 +306,23 @@ async function saveSettings() {
 // Fetch Ollama models from API
 async function fetchOllamaModels() {
     try {
-        const ollamaUrl = document.getElementById('ollama-url').value.replace(/\/+$/, '') || DEFAULT_OLLAMA_URL;
+        const ollamaUrl = getOllamaEffectiveUrl();
         const selectElement = document.getElementById('ollama-model');
-        
+
         // Remember current selection before clearing
         const currentSelection = selectElement.value;
-        
-        const data = await sendBackgroundMessage('FETCH_API_REQUEST', {
+
+        const fetchOptions = {
             url: `${ollamaUrl}/api/tags`,
             method: 'GET',
-            isErrorExpected: true  // Ollama not running is expected, suppress error logs
-        });
+            isErrorExpected: true
+        };
+        const extraHeaders = getOllamaFetchHeaders();
+        if (Object.keys(extraHeaders).length > 0) {
+            fetchOptions.headers = extraHeaders;
+        }
+
+        const data = await sendBackgroundMessage('FETCH_API_REQUEST', fetchOptions);
 
         // Clear existing options
         selectElement.options.length = 0
@@ -244,21 +335,44 @@ async function fetchOllamaModels() {
             selectElement.appendChild(option);
         }
         else {
-            // Add models to select element
-            data.models.forEach(model => {
-                const option = document.createElement('option');
-                option.value = model.name;
-                option.textContent = model.name;
-                selectElement.appendChild(option);
-            });
+            const models = data.models.map(m => m.name).sort();
+
+            if (isOllamaCloudMode()) {
+                const grouped = new Map();
+                for (const name of models) {
+                    const slashIdx = name.indexOf('/');
+                    const provider = slashIdx > 0 ? name.substring(0, slashIdx) : 'ollama';
+                    const modelName = slashIdx > 0 ? name.substring(slashIdx + 1) : name;
+                    if (!grouped.has(provider)) grouped.set(provider, []);
+                    grouped.get(provider).push({ value: name, label: modelName });
+                }
+                const sortedProviders = [...grouped.keys()].sort();
+                for (const provider of sortedProviders) {
+                    const optgroup = document.createElement('optgroup');
+                    optgroup.label = provider;
+                    for (const model of grouped.get(provider)) {
+                        const option = document.createElement('option');
+                        option.value = model.value;
+                        option.textContent = model.label;
+                        optgroup.appendChild(option);
+                    }
+                    selectElement.appendChild(optgroup);
+                }
+            } else {
+                for (const name of models) {
+                    const option = document.createElement('option');
+                    option.value = name;
+                    option.textContent = name;
+                    selectElement.appendChild(option);
+                }
+            }
 
             // Restore selection: prefer current selection, fall back to saved settings
             const settings = await storage.getItem('sync:settings');
             const savedModel = settings?.ollama?.model;
             const modelToSelect = currentSelection || savedModel;
-            
+
             if (modelToSelect) {
-                // Check if the model exists in the options
                 const optionExists = Array.from(selectElement.options).some(opt => opt.value === modelToSelect);
                 if (optionExists) {
                     selectElement.value = modelToSelect;
@@ -296,13 +410,21 @@ async function loadSettings() {
             // Set provider selection in dropdown (can be empty string for "None")
             const providerDropdown = document.getElementById('active-provider');
             if (providerDropdown && settings.providerSelection !== undefined) {
-                providerDropdown.value = settings.providerSelection;
+                const dropdownValue = (settings.providerSelection === 'ollama' && settings.ollama?.cloud)
+                    ? 'ollama-cloud'
+                    : settings.providerSelection;
+                providerDropdown.value = dropdownValue;
             }
-            updateActiveProviderBadge(settings.providerSelection ?? '');
+            const badgeValue = (settings.providerSelection === 'ollama' && settings.ollama?.cloud)
+                ? 'ollama-cloud'
+                : (settings.providerSelection ?? '');
+            updateActiveProviderBadge(badgeValue);
 
             // Set Ollama settings
             if (settings.ollama) {
+                setOllamaMode(settings.ollama.cloud || false);
                 document.getElementById('ollama-url').value = settings.ollama.url || DEFAULT_OLLAMA_URL;
+                document.getElementById('ollama-key').value = settings.ollama.apiKey || '';
                 if (settings.ollama.model) {
                     document.getElementById('ollama-model').value = settings.ollama.model;
                 }
@@ -367,7 +489,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     await loadSettings();
 
     // Only attempt to load Ollama models if permission is already granted
-    if (await hasOptionalHostPermissions(OPTIONAL_HOST_PERMISSIONS.ollama)) {
+    const ollamaPermKey = isOllamaCloudMode() ? 'ollama-cloud' : 'ollama';
+    if (await hasOptionalHostPermissions(OPTIONAL_HOST_PERMISSIONS[ollamaPermKey])) {
         await fetchOllamaModels();
     } else {
         setOllamaModelSelectStatus('Expand to load models');
@@ -386,7 +509,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         const providerSelection = document.getElementById('active-provider').value; // Can be empty for "None"
 
         // 2. Request permission FIRST (MUST be first await to preserve user gesture in Firefox)
-        const origins = OPTIONAL_HOST_PERMISSIONS[providerSelection] || [];
+        const permKey = providerSelection === 'ollama-cloud' ? 'ollama-cloud' : providerSelection;
+        const origins = OPTIONAL_HOST_PERMISSIONS[permKey] || [];
         if (origins.length > 0) {
             const permissionGranted = await requestOptionalHostPermissions(origins);
             if (!permissionGranted) {
@@ -440,6 +564,36 @@ document.addEventListener('DOMContentLoaded', async () => {
     const promptCustomizationCheckbox = document.getElementById('prompt-customization');
     promptCustomizationCheckbox.addEventListener('change', (e) => {
         setPromptCustomizationState(e.target.checked);
+    });
+
+    // Ollama local/cloud mode toggle buttons — sync with active provider dropdown
+    const syncDropdownToOllamaMode = (isCloud) => {
+        const dropdown = document.getElementById('active-provider');
+        const currentIsOllama = dropdown.value === 'ollama' || dropdown.value === 'ollama-cloud';
+        if (currentIsOllama) {
+            dropdown.value = isCloud ? 'ollama-cloud' : 'ollama';
+            updateActiveProviderBadge(dropdown.value);
+        }
+    };
+
+    document.getElementById('ollama-mode-local').addEventListener('click', () => {
+        setOllamaMode(false);
+        syncDropdownToOllamaMode(false);
+        fetchOllamaModels();
+    });
+    document.getElementById('ollama-mode-cloud').addEventListener('click', async () => {
+        setOllamaMode(true);
+        syncDropdownToOllamaMode(true);
+        const origins = OPTIONAL_HOST_PERMISSIONS['ollama-cloud'];
+        let granted = await hasOptionalHostPermissions(origins);
+        if (!granted) {
+            granted = await requestOptionalHostPermissions(origins);
+        }
+        if (granted) {
+            await fetchOllamaModels();
+        } else {
+            setOllamaModelSelectStatus('Permission required to load models');
+        }
     });
 
     setupKeyVisibilityToggles();

--- a/src/lib/llm-summarizer.js
+++ b/src/lib/llm-summarizer.js
@@ -1,4 +1,4 @@
-import {generateText} from 'ai';
+import {generateText, streamText} from 'ai';
 
 import {createOpenAI} from '@ai-sdk/openai';
 import {createAnthropic} from '@ai-sdk/anthropic';
@@ -6,54 +6,49 @@ import {createGoogleGenerativeAI} from '@ai-sdk/google';
 import {createOpenRouter} from '@openrouter/ai-sdk-provider';
 import {Logger} from "./utils.js";
 
+function createModel(aiProvider, modelId, apiKey) {
+    switch (aiProvider) {
+        case 'openai':
+            return createOpenAI({ apiKey })(modelId);
+
+        case 'anthropic':
+            return createAnthropic({
+                apiKey,
+                headers: { 'anthropic-dangerous-direct-browser-access': 'true' },
+            })(modelId);
+
+        case 'google':
+            return createGoogleGenerativeAI({ apiKey })(modelId);
+
+        case 'openrouter':
+            return createOpenRouter({ apiKey }).chat(modelId);
+
+        default:
+            throw new Error(`Unsupported AI provider: ${aiProvider}, model: ${modelId}`);
+    }
+}
+
+function improveError(error, data) {
+    const errorPrefix = `AI SDK API error. Reason: ${error.reason}. ` +
+        `AI Provider: ${data?.aiProvider}, Model: ${data?.modelId}`;
+    if (error instanceof Error) {
+        error.message = `${errorPrefix} Message: ${error.message}`;
+        return error;
+    }
+    return new Error(`${errorPrefix}. Message: ${String(error)}`);
+}
+
 export async function summarizeText(data) {
     try {
-
         const { aiProvider, modelId, apiKey, systemPrompt, userPrompt, parameters = {} } = data;
 
-        let model;
-        switch (aiProvider) {
-            // AI provider can be 'openai', 'anthropic', 'google' or 'openrouter'
-            case 'openai':
-                const openai = createOpenAI({
-                    apiKey: apiKey,
-                });
-                model = openai(modelId);
-                break;
-
-            case 'anthropic':
-                const anthropic = createAnthropic({
-                    apiKey: apiKey,
-                    headers: {
-                        'anthropic-dangerous-direct-browser-access': 'true',
-                    },
-                });
-                model = anthropic(modelId);
-                break;
-
-            case 'google':
-                const google = createGoogleGenerativeAI({
-                    apiKey: apiKey,
-                });
-                model = google(modelId);
-                break;
-
-            case 'openrouter':
-                const openRouter = createOpenRouter({
-                    apiKey: apiKey,
-                });
-                model = openRouter.chat(modelId);
-                break;
-
-            default:
-                throw new Error(`Unsupported AI provider: ${aiProvider}, model: ${modelId}`);
-        }
+        const model = createModel(aiProvider, modelId, apiKey);
         if (!model) {
             throw new Error(`Failed to initialize model for provider: ${aiProvider}, model: ${modelId}`);
         }
 
         const { text: summary } = await generateText({
-            model: model,
+            model,
             system: systemPrompt,
             prompt: userPrompt,
             temperature: parameters.temperature,
@@ -64,21 +59,48 @@ export async function summarizeText(data) {
         });
 
         await Logger.debug('Summarized text success. Summary:', summary);
-
         return summary;
 
     } catch (caughtError) {
-        const improveError = (error) => {
-            const errorPrefix = `AI SDK API generateText() threw error. Reason: ${error.reason}. ` +
-                `AI Provider: ${data?.aiProvider}, Model: ${data?.modelId}`;
-            if (error instanceof Error) {
-                error.message = `${errorPrefix} Message: ${error.message}`;
-                return  error;
-            }
-            return  new Error(`${errorPrefix}. Message: ${String(error)}`);
-        }
-        const error = improveError(caughtError);
+        const error = improveError(caughtError, data);
         await Logger.error(error);
         throw error;
+    }
+}
+
+export async function streamSummarizeText(data, onChunk, onDone, onError, abortSignal) {
+    try {
+        const { aiProvider, modelId, apiKey, systemPrompt, userPrompt, parameters = {} } = data;
+
+        const model = createModel(aiProvider, modelId, apiKey);
+        if (!model) {
+            throw new Error(`Failed to initialize model for provider: ${aiProvider}, model: ${modelId}`);
+        }
+
+        const result = streamText({
+            model,
+            system: systemPrompt,
+            prompt: userPrompt,
+            temperature: parameters.temperature,
+            topP: parameters.topP,
+            frequencyPenalty: parameters.frequencyPenalty,
+            presencePenalty: parameters.presencePenalty,
+            maxOutputTokens: parameters.maxOutputTokens,
+            abortSignal
+        });
+
+        for await (const delta of result.textStream) {
+            if (abortSignal?.aborted) break;
+            onChunk(delta);
+        }
+
+        const fullText = await result.text;
+        onDone(fullText);
+
+    } catch (caughtError) {
+        if (abortSignal?.aborted) return;
+        const error = improveError(caughtError, data);
+        await Logger.error(error);
+        onError(error);
     }
 }

--- a/src/lib/messaging.js
+++ b/src/lib/messaging.js
@@ -41,3 +41,38 @@ export async function sendBackgroundMessage(type, data) {
     responseData.duration = duration;
     return responseData;
 }
+
+export function sendStreamingMessage(type, data, onChunk) {
+    return new Promise((resolve, reject) => {
+        const startTime = performance.now();
+        const port = browser.runtime.connect({ name: 'HN_STREAM' });
+
+        port.onMessage.addListener((message) => {
+            switch (message.type) {
+                case 'chunk':
+                    onChunk(message.delta);
+                    break;
+                case 'done': {
+                    const duration = Math.round((performance.now() - startTime) / 1000);
+                    port.disconnect();
+                    resolve({ summary: message.text, duration });
+                    break;
+                }
+                case 'error': {
+                    port.disconnect();
+                    reject(new Error(message.error));
+                    break;
+                }
+            }
+        });
+
+        port.onDisconnect.addListener(() => {
+            const error = browser.runtime.lastError;
+            if (error) {
+                reject(new Error(error.message || 'Port disconnected'));
+            }
+        });
+
+        port.postMessage({ type, data });
+    });
+}

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -22,7 +22,6 @@ export default defineConfig({
                 "https://api.anthropic.com/*",
                 "https://openrouter.ai/*",
                 "https://generativelanguage.googleapis.com/*",
-                "http://localhost:11434/*",
                 "https://ollama.com/*"
             ],
             icons: {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
                 "https://api.anthropic.com/*",
                 "https://openrouter.ai/*",
                 "https://generativelanguage.googleapis.com/*",
+                "http://localhost:11434/*",
                 "https://ollama.com/*"
             ],
             icons: {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -22,7 +22,8 @@ export default defineConfig({
                 "https://api.anthropic.com/*",
                 "https://openrouter.ai/*",
                 "https://generativelanguage.googleapis.com/*",
-                "http://localhost:11434/*"
+                "http://localhost:11434/*",
+                "https://ollama.com/*"
             ],
             icons: {
                 16: '/icon/icon-16.png',


### PR DESCRIPTION
Hey George, Ann! 👋

This builds on #24 (Ollama Cloud) and adds **streaming responses** for all cloud providers. Instead of staring at a spinner for 20-30 seconds, users now see the summary building up in real-time with proper markdown formatting — headers, bullets, bold text appear as the LLM generates them.

## How it works

The existing `sendMessage` → `generateText` pipeline was one-shot — wait for the full response, then render. This PR adds a parallel **port-based streaming pipeline**:

```
Content Script ←→ Background Worker ←→ LLM
    port.connect("HN_STREAM")
    ← chunk (text delta)
    ← chunk (text delta)
    ← ...
    ← done (full text)
```

During streaming, the accumulated text is re-parsed through `marked.parse()` every 150ms, so users see formatted markdown building up progressively. On completion, the final render adds comment backlinks.

## What streams

| Provider | Before | After |
|----------|--------|-------|
| OpenAI, Anthropic, Google, OpenRouter | Spinner → full summary | Progressive markdown |
| Ollama Cloud | Spinner → full summary | Progressive markdown (NDJSON) |
| Ollama Local | Single-shot | Unchanged (localhost, fast enough) |
| Cached summaries | Instant | Unchanged |

## Files changed

- **`llm-summarizer.js`** — Extracted `createModel()` helper, added `streamSummarizeText()` using `streamText()` from Vercel AI SDK with `AbortSignal` support
- **`messaging.js`** — Added `sendStreamingMessage()` using `chrome.runtime.connect()` ports
- **`background/index.js`** — Added `onConnect` listener for `HN_STREAM` port, handles both AI SDK streaming and Ollama NDJSON streaming
- **`ai-summarizer.js`** — `onChunk` parameter on `summarizeTextWithLLM()` and `summarizeUsingOllama()`, routes to streaming or single-shot path
- **`summary-panel.js`** — `appendStreamingText()` with throttled `marked.parse()` re-renders, `finishStreaming()` cleanup, streaming metadata chip
- **`hnenhancer.js`** — Wires up `onChunk` callback for cloud providers and Ollama Cloud
- **`styles.css`** — Streaming chip with pulse animation

## Tested

Puppeteer e2e with Ollama Cloud (`glm-5.1`):
- First formatted text appeared at **7s** (vs 25s+ before)
- Headers and bullets rendered progressively during streaming
- Final render at **27s** with all markdown formatting and backlinks
- "Streaming" chip with pulse animation visible during generation
- "Generated 18s | ollama/glm-5.1" metadata on completion

## Test plan

- [ ] Trigger summarization with any cloud provider — text should stream in with markdown formatting
- [ ] Verify "Streaming" chip appears with pulse animation during generation
- [ ] Verify final render has clickable comment backlinks
- [ ] Navigate away mid-stream — no errors in console
- [ ] Verify Ollama Local still works single-shot
- [ ] Verify cached summaries still load instantly

Excited about this one — the streaming UX makes the extension feel much snappier! Let me know what you think.