### PR TITLE
Add streaming LLM responses with progressive markdown rendering

### DIFF
--- a/src/entrypoints/background/index.js
+++ b/src/entrypoints/background/index.js
@@ -131,14 +131,19 @@ export default defineBackground(() => {
                 );
             } else if (message.type === 'HN_STREAM_OLLAMA') {
                 abortController = new AbortController();
+                let timedOut = false;
+                let timeoutId = null;
+                const timeoutMs = message.data.timeout || 180_000;
                 try {
-                    const { url, method, headers, body, timeout } = message.data;
-                    const id = setTimeout(() => abortController.abort(), timeout || 180_000);
+                    const { url, method, headers, body } = message.data;
+                    timeoutId = setTimeout(() => {
+                        timedOut = true;
+                        abortController.abort();
+                    }, timeoutMs);
                     const response = await fetch(url, {
                         method, headers, body,
                         signal: abortController.signal
                     });
-                    clearTimeout(id);
 
                     if (!response.ok) {
                         const errorText = await response.text();
@@ -149,34 +154,62 @@ export default defineBackground(() => {
                     const reader = response.body.getReader();
                     const decoder = new TextDecoder();
                     let fullText = '';
+                    let buffer = '';
+
+                    // Process one complete NDJSON line. Returns true when the
+                    // stream signalled done so the caller can stop early.
+                    const handleLine = (line) => {
+                        if (!line.trim()) return false;
+                        try {
+                            const parsed = JSON.parse(line);
+                            if (parsed.response) {
+                                fullText += parsed.response;
+                                safeSend({ type: 'chunk', delta: parsed.response });
+                            }
+                            if (parsed.done) {
+                                safeSend({ type: 'done', text: fullText });
+                                return true;
+                            }
+                        } catch (_) { /* skip malformed lines */ }
+                        return false;
+                    };
 
                     while (true) {
                         const { done, value } = await reader.read();
                         if (done) break;
                         if (abortController.signal.aborted) break;
 
-                        const chunk = decoder.decode(value, { stream: true });
-                        for (const line of chunk.split('\n')) {
-                            if (!line.trim()) continue;
-                            try {
-                                const parsed = JSON.parse(line);
-                                if (parsed.response) {
-                                    fullText += parsed.response;
-                                    safeSend({ type: 'chunk', delta: parsed.response });
-                                }
-                                if (parsed.done) {
-                                    safeSend({ type: 'done', text: fullText });
-                                    return;
-                                }
-                            } catch (_) { /* skip malformed lines */ }
+                        // Buffer across reads: a JSON object may be split over
+                        // two chunks, so only the trailing partial line is held
+                        // back until its newline arrives.
+                        buffer += decoder.decode(value, { stream: true });
+                        const lines = buffer.split('\n');
+                        buffer = lines.pop() ?? '';
+                        for (const line of lines) {
+                            if (handleLine(line)) return;
                         }
                     }
 
+                    if (abortController.signal.aborted) {
+                        if (timedOut) {
+                            safeSend({ type: 'error', error: `Request timed out after ${Math.round(timeoutMs / 1000)}s` });
+                        }
+                        return;
+                    }
+
+                    // Flush any final line left without a trailing newline.
+                    buffer += decoder.decode();
+                    if (handleLine(buffer)) return;
+
                     safeSend({ type: 'done', text: fullText });
                 } catch (error) {
-                    if (!abortController.signal.aborted) {
+                    if (timedOut) {
+                        safeSend({ type: 'error', error: `Request timed out after ${Math.round(timeoutMs / 1000)}s` });
+                    } else if (!abortController.signal.aborted) {
                         safeSend({ type: 'error', error: error.toString() });
                     }
+                } finally {
+                    if (timeoutId) clearTimeout(timeoutId);
                 }
             }
         });

--- a/src/entrypoints/background/index.js
+++ b/src/entrypoints/background/index.js
@@ -1,4 +1,4 @@
-import {summarizeText} from '../../lib/llm-summarizer.js';
+import {summarizeText, streamSummarizeText} from '../../lib/llm-summarizer.js';
 import { storage } from '#imports';
 import {browser} from "wxt/browser";
 import {Logger} from "../../lib/utils.js";
@@ -103,6 +103,83 @@ export default defineBackground(() => {
             default:
                 Logger.infoSync('Unknown message type:', message.type);
         }
+    });
+
+    // Handle streaming connections via ports
+    browser.runtime.onConnect.addListener((port) => {
+        if (port.name !== 'HN_STREAM') return;
+
+        let abortController = null;
+
+        port.onDisconnect.addListener(() => {
+            if (abortController) abortController.abort();
+        });
+
+        port.onMessage.addListener(async (message) => {
+            const safeSend = (msg) => {
+                try { port.postMessage(msg); } catch (_) { /* port disconnected */ }
+            };
+
+            if (message.type === 'HN_STREAM_SUMMARIZE') {
+                abortController = new AbortController();
+                await streamSummarizeText(
+                    message.data,
+                    (delta) => safeSend({ type: 'chunk', delta }),
+                    (fullText) => safeSend({ type: 'done', text: fullText }),
+                    (error) => safeSend({ type: 'error', error: error.toString() }),
+                    abortController.signal
+                );
+            } else if (message.type === 'HN_STREAM_OLLAMA') {
+                abortController = new AbortController();
+                try {
+                    const { url, method, headers, body, timeout } = message.data;
+                    const id = setTimeout(() => abortController.abort(), timeout || 180_000);
+                    const response = await fetch(url, {
+                        method, headers, body,
+                        signal: abortController.signal
+                    });
+                    clearTimeout(id);
+
+                    if (!response.ok) {
+                        const errorText = await response.text();
+                        safeSend({ type: 'error', error: `API Error: HTTP ${response.status} ${errorText}` });
+                        return;
+                    }
+
+                    const reader = response.body.getReader();
+                    const decoder = new TextDecoder();
+                    let fullText = '';
+
+                    while (true) {
+                        const { done, value } = await reader.read();
+                        if (done) break;
+                        if (abortController.signal.aborted) break;
+
+                        const chunk = decoder.decode(value, { stream: true });
+                        for (const line of chunk.split('\n')) {
+                            if (!line.trim()) continue;
+                            try {
+                                const parsed = JSON.parse(line);
+                                if (parsed.response) {
+                                    fullText += parsed.response;
+                                    safeSend({ type: 'chunk', delta: parsed.response });
+                                }
+                                if (parsed.done) {
+                                    safeSend({ type: 'done', text: fullText });
+                                    return;
+                                }
+                            } catch (_) { /* skip malformed lines */ }
+                        }
+                    }
+
+                    safeSend({ type: 'done', text: fullText });
+                } catch (error) {
+                    if (!abortController.signal.aborted) {
+                        safeSend({ type: 'error', error: error.toString() });
+                    }
+                }
+            }
+        });
     });
 
     // Handle async message and send response

--- a/src/entrypoints/content/ai-summarizer.js
+++ b/src/entrypoints/content/ai-summarizer.js
@@ -449,8 +449,7 @@ export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathTo
         headers['Authorization'] = `Bearer ${apiKey}`;
     }
 
-    // Ollama Cloud: stream via port
-    if (apiKey && onChunk) {
+    if (onChunk) {
         const payload = { model, system: systemMessage, prompt: userMessage, stream: true };
         sendStreamingMessage('HN_STREAM_OLLAMA', {
             url: endpoint, method: 'POST', headers,
@@ -462,29 +461,26 @@ export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathTo
             }
             onSuccess(summary, data.duration, commentPathToIdMap);
         }).catch(error => {
-            Logger.errorSync('Ollama Cloud streaming failed:', error.message);
+            Logger.errorSync('Ollama streaming failed:', error.message);
             onError(error);
         });
         return;
     }
 
-    // Ollama Local: single-shot fetch
     const payload = { model, system: systemMessage, prompt: userMessage, stream: false };
-
     sendBackgroundMessage('FETCH_API_REQUEST', {
         url: endpoint,
         method: 'POST',
         headers,
         body: JSON.stringify(payload),
         timeout: 180_000
-    })
-        .then(data => {
-            const summary = data.response;
-            if (!summary) {
-                throw new Error('No summary generated from API response');
-            }
-            onSuccess(summary, data.duration, commentPathToIdMap);
-        }).catch(error => {
+    }).then(data => {
+        const summary = data.response;
+        if (!summary) {
+            throw new Error('No summary generated from API response');
+        }
+        onSuccess(summary, data.duration, commentPathToIdMap);
+    }).catch(error => {
         Logger.errorSync('Error in Ollama summarization:', error);
         onError(error);
     });

--- a/src/entrypoints/content/ai-summarizer.js
+++ b/src/entrypoints/content/ai-summarizer.js
@@ -496,21 +496,14 @@ export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathTo
  * @returns {DocumentFragment|string}
  */
 export function createOllamaErrorMessage(error) {
-    // For 403 errors, show detailed CORS instructions using markdown
     if (error.message?.includes('403')) {
-        const errorMarkdown = `Ollama blocked the request (likely a CORS or server configuration issue).
-
-**To fix:**
-
-1. Restart Ollama with CORS enabled:
-   \`\`\`
-   OLLAMA_ORIGINS="chrome-extension://*,moz-extension://*" ollama serve
-   \`\`\`
-
-2. Verify the Ollama URL in the extension settings and ensure Ollama is running.
-
-*If the problem continues, check Ollama logs or the extension settings for more details.*`;
-        return createSummaryFragment(errorMarkdown, new Map());
+        return createErrorElement({
+            type: 'network',
+            title: 'Ollama Blocked the Request',
+            description: 'Ollama rejected the request because the browser extension origin is not allowed. You need to start Ollama with CORS enabled.',
+            action: { label: 'Open Settings', id: 'error-open-settings' },
+            hint: 'Run: <code>OLLAMA_ORIGINS="chrome-extension://*,moz-extension://*" ollama serve</code><br>See the setup guide in extension settings for Windows instructions.'
+        });
     }
 
     // For network errors, use the styled error element

--- a/src/entrypoints/content/ai-summarizer.js
+++ b/src/entrypoints/content/ai-summarizer.js
@@ -5,7 +5,7 @@
 
 import {storage} from '#imports';
 import {Logger} from "../../lib/utils.js";
-import {sendBackgroundMessage} from "../../lib/messaging.js";
+import {sendBackgroundMessage, sendStreamingMessage} from "../../lib/messaging.js";
 import {AI_SYSTEM_PROMPT, AI_USER_PROMPT_TEMPLATE} from './constants.js';
 // Import generic utilities from lib
 import {buildFragment, createStrong, createInternalLink, createExternalLink} from '../../lib/dom-utils.js';
@@ -366,7 +366,7 @@ export function formatSummaryError(error) {
  * @param {Function} onError - Error callback (error)
  * @param {string} postTitle - Title of the post
  */
-export async function summarizeTextWithLLM(aiProvider, modelId, apiKey, text, commentPathToIdMap, onSuccess, onError, postTitle) {
+export async function summarizeTextWithLLM(aiProvider, modelId, apiKey, text, commentPathToIdMap, onSuccess, onError, postTitle, onChunk) {
     if (!text || !aiProvider || !modelId || !apiKey) {
         await Logger.error('Missing required parameters for AI summarization');
         onError(new Error('Missing AI configuration'));
@@ -398,16 +398,29 @@ export async function summarizeTextWithLLM(aiProvider, modelId, apiKey, text, co
         parameters,
     };
 
-    sendBackgroundMessage('HN_SUMMARIZE', llmInput).then(data => {
-        const summary = data?.summary;
-        if (!summary) {
-            throw new Error('Empty summary returned from background message HN_SUMMARIZE. data: ' + JSON.stringify(data));
-        }
-        onSuccess(summary, data.duration, commentPathToIdMap);
-    }).catch(error => {
-        Logger.errorSync('LLM summarization failed in summarizeTextWithLLM(). Error:', error.message);
-        onError(error);
-    });
+    if (onChunk) {
+        sendStreamingMessage('HN_STREAM_SUMMARIZE', llmInput, onChunk).then(data => {
+            const summary = data?.summary;
+            if (!summary) {
+                throw new Error('Empty summary returned from streaming');
+            }
+            onSuccess(summary, data.duration, commentPathToIdMap);
+        }).catch(error => {
+            Logger.errorSync('LLM streaming failed:', error.message);
+            onError(error);
+        });
+    } else {
+        sendBackgroundMessage('HN_SUMMARIZE', llmInput).then(data => {
+            const summary = data?.summary;
+            if (!summary) {
+                throw new Error('Empty summary returned from background message HN_SUMMARIZE. data: ' + JSON.stringify(data));
+            }
+            onSuccess(summary, data.duration, commentPathToIdMap);
+        }).catch(error => {
+            Logger.errorSync('LLM summarization failed in summarizeTextWithLLM(). Error:', error.message);
+            onError(error);
+        });
+    }
 }
 
 /**
@@ -420,7 +433,7 @@ export async function summarizeTextWithLLM(aiProvider, modelId, apiKey, text, co
  * @param {Function} onError - Error callback (error)
  * @param {string} postTitle - Title of the post
  */
-export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathToIdMap, onSuccess, onError, postTitle, apiKey) {
+export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathToIdMap, onSuccess, onError, postTitle, apiKey, onChunk) {
     if (!text || !model) {
         await Logger.error('Missing required parameters for Ollama summarization');
         onError(new Error('Missing Ollama configuration'));
@@ -431,17 +444,32 @@ export async function summarizeUsingOllama(text, model, ollamaUrl, commentPathTo
     const systemMessage = await getSystemMessage();
     const userMessage = await getUserMessage(postTitle, text);
 
-    const payload = {
-        model: model,
-        system: systemMessage,
-        prompt: userMessage,
-        stream: false
-    };
-
     const headers = { 'Content-Type': 'application/json' };
     if (apiKey) {
         headers['Authorization'] = `Bearer ${apiKey}`;
     }
+
+    // Ollama Cloud: stream via port
+    if (apiKey && onChunk) {
+        const payload = { model, system: systemMessage, prompt: userMessage, stream: true };
+        sendStreamingMessage('HN_STREAM_OLLAMA', {
+            url: endpoint, method: 'POST', headers,
+            body: JSON.stringify(payload), timeout: 180_000
+        }, onChunk).then(data => {
+            const summary = data?.summary;
+            if (!summary) {
+                throw new Error('No summary generated from streaming Ollama response');
+            }
+            onSuccess(summary, data.duration, commentPathToIdMap);
+        }).catch(error => {
+            Logger.errorSync('Ollama Cloud streaming failed:', error.message);
+            onError(error);
+        });
+        return;
+    }
+
+    // Ollama Local: single-shot fetch
+    const payload = { model, system: systemMessage, prompt: userMessage, stream: false };
 
     sendBackgroundMessage('FETCH_API_REQUEST', {
         url: endpoint,

--- a/src/entrypoints/content/hnenhancer.js
+++ b/src/entrypoints/content/hnenhancer.js
@@ -628,7 +628,7 @@ class HNEnhancer {
                         },
                         postTitle,
                         ollamaApiKey,
-                        ollamaCloud ? onChunk : undefined
+                        onChunk
                     );
                     break;
                 case 'openai':

--- a/src/entrypoints/content/hnenhancer.js
+++ b/src/entrypoints/content/hnenhancer.js
@@ -578,13 +578,27 @@ class HNEnhancer {
             formattedComment = stripAnchors(formattedComment);
             const postTitle = this.getHNPostTitle();
 
+            let streamingStarted = false;
+            const onChunk = (delta) => {
+                if (!streamingStarted) {
+                    streamingStarted = true;
+                    this.summaryPanel.updateMetadataRow({
+                        state: 'streaming',
+                        provider: `${aiProvider}/${model || ''}`
+                    });
+                }
+                this.summaryPanel.appendStreamingText(delta);
+            };
+
             const onSuccess = (summary, duration, pathMap) => {
+                this.summaryPanel.finishStreaming();
                 this.showSummaryInPanel(summary, false, duration, pathMap, itemId).catch(error => {
                     Logger.errorSync('Error showing summary:', error);
                 });
             };
 
             const onError = (error) => {
+                this.summaryPanel.finishStreaming();
                 this.handleSummaryError(error);
             };
 
@@ -604,6 +618,7 @@ class HNEnhancer {
                         formattedComment, model, ollamaUrl, commentPathToIdMap,
                         onSuccess,
                         (error) => {
+                            this.summaryPanel.finishStreaming();
                             const errorFragment = createOllamaErrorMessage(error);
                             this.summaryPanel.updateContent({
                                 text: errorFragment,
@@ -612,7 +627,8 @@ class HNEnhancer {
                             this.attachErrorActionListeners();
                         },
                         postTitle,
-                        ollamaApiKey
+                        ollamaApiKey,
+                        ollamaCloud ? onChunk : undefined
                     );
                     break;
                 case 'openai':
@@ -622,7 +638,8 @@ class HNEnhancer {
                     const apiKey = settings?.[aiProvider]?.apiKey;
                     await summarizeTextWithLLM(
                         aiProvider, model, apiKey, formattedComment, commentPathToIdMap,
-                        onSuccess, onError, postTitle
+                        onSuccess, onError, postTitle,
+                        onChunk
                     );
                     break;
                 default:

--- a/src/entrypoints/content/hnenhancer.js
+++ b/src/entrypoints/content/hnenhancer.js
@@ -83,6 +83,7 @@ class HNEnhancer {
             this.commentNavigator.setupCommentClickHandlers();
             this.commentNavigator.navigateToFirstComment(false);
             this.summaryPanel = new SummaryPanel();
+            this.setupSummaryPanelCommentLinks();
 
             // Wire up refresh button to force-refresh summary
             if (this.summaryPanel) {
@@ -586,6 +587,7 @@ class HNEnhancer {
                         state: 'streaming',
                         provider: `${aiProvider}/${model || ''}`
                     });
+                    this.summaryPanel.beginStreaming(commentPathToIdMap);
                 }
                 this.summaryPanel.appendStreamingText(delta);
             };
@@ -719,17 +721,22 @@ class HNEnhancer {
             });
         }
 
-        document.querySelectorAll('[data-comment-link="true"]').forEach(link => {
-            link.addEventListener('click', (e) => {
-                e.preventDefault();
-                const id = link.dataset.commentId;
-                const comment = document.getElementById(id);
-                if (comment) {
-                    this.setCurrentComment(comment);
-                } else {
-                    Logger.infoSync('Failed to find DOM element for comment id:', id);
-                }
-            });
+    }
+
+    setupSummaryPanelCommentLinks() {
+        this.summaryPanel?.panel?.addEventListener('click', (e) => {
+            if (!(e.target instanceof Element)) return;
+            const link = e.target.closest('[data-comment-link="true"]');
+            if (!link || !this.summaryPanel.panel.contains(link)) return;
+
+            e.preventDefault();
+            const id = link.dataset.commentId;
+            const comment = document.getElementById(id);
+            if (comment) {
+                this.setCurrentComment(comment);
+            } else {
+                Logger.infoSync('Failed to find DOM element for comment id:', id);
+            }
         });
     }
 

--- a/src/entrypoints/content/styles.css
+++ b/src/entrypoints/content/styles.css
@@ -505,6 +505,17 @@
     color: #4a7c4a;
 }
 
+.summary-metadata-chip-streaming {
+    background-color: #e0e8f0;
+    color: #3a6a8a;
+    animation: streaming-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes streaming-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+}
+
 .summary-metadata-provider-link,
 .summary-metadata-provider-link:link,
 .summary-metadata-provider-link:visited {

--- a/src/entrypoints/content/summary-panel.js
+++ b/src/entrypoints/content/summary-panel.js
@@ -1,8 +1,6 @@
 import {storage} from '#imports';
 import {browser} from 'wxt/browser';
-import {qualifyCommentLinks} from './comment-processor.js';
-import {marked} from 'marked';
-import {sanitizeHtmlToFragment, enforceSafeLinks} from '../../lib/sanitize.js';
+import {qualifyCommentLinks, createSummaryFragment} from './comment-processor.js';
 
 // SVG Icon constants
 const ICONS = {
@@ -815,6 +813,15 @@ class SummaryPanel {
             container.appendChild(providerLink);
         }
     }
+    /**
+     * Prepares the panel for a streaming render pass.
+     * @param {Map} [commentPathToIdMap] - Map of path → comment ID so backlinks
+     *        can be rendered live, identical to the final summary render.
+     */
+    beginStreaming(commentPathToIdMap) {
+        this._streamCommentMap = commentPathToIdMap ?? null;
+    }
+
     appendStreamingText(delta) {
         if (!this.panel) return;
         const textElement = this.panel.querySelector('.summary-text');
@@ -838,17 +845,24 @@ class SummaryPanel {
 
     _renderStreamedMarkdown(textElement) {
         if (!this._streamBuffer) return;
+
+        // Preserve the reader's scroll position: only auto-scroll if they're
+        // already pinned near the bottom, so scrolling up mid-stream sticks.
+        const content = this.panel?.querySelector('.summary-panel-content');
+        const wasNearBottom = content
+            ? content.scrollHeight - content.scrollTop - content.clientHeight < 50
+            : true;
+
         try {
-            const html = marked.parse(this._streamBuffer);
-            const fragment = sanitizeHtmlToFragment(html);
-            enforceSafeLinks(fragment);
+            // Reuse the same pipeline as the final render so comment backlinks
+            // appear live and the completed summary is visually identical.
+            const fragment = createSummaryFragment(this._streamBuffer, this._streamCommentMap);
             this.setElementContent(textElement, fragment);
         } catch (_) {
             textElement.textContent = this._streamBuffer;
         }
 
-        const content = this.panel?.querySelector('.summary-panel-content');
-        if (content) {
+        if (content && wasNearBottom) {
             content.scrollTop = content.scrollHeight;
         }
     }
@@ -860,6 +874,7 @@ class SummaryPanel {
         }
         this._isStreaming = false;
         this._streamBuffer = '';
+        this._streamCommentMap = null;
     }
 
     renderStreamingMetadata(container, metadata) {

--- a/src/entrypoints/content/summary-panel.js
+++ b/src/entrypoints/content/summary-panel.js
@@ -1,6 +1,8 @@
 import {storage} from '#imports';
 import {browser} from 'wxt/browser';
 import {qualifyCommentLinks} from './comment-processor.js';
+import {marked} from 'marked';
+import {sanitizeHtmlToFragment, enforceSafeLinks} from '../../lib/sanitize.js';
 
 // SVG Icon constants
 const ICONS = {
@@ -739,6 +741,8 @@ class SummaryPanel {
             this.renderCachedMetadata(metadataInfo, metadata);
         } else if (metadata.state === 'generated') {
             this.renderGeneratedMetadata(metadataInfo, metadata);
+        } else if (metadata.state === 'streaming') {
+            this.renderStreamingMetadata(metadataInfo, metadata);
         }
     }
 
@@ -809,6 +813,71 @@ class SummaryPanel {
                 browser.runtime.sendMessage({ type: 'HN_SHOW_OPTIONS', data: {} });
             });
             container.appendChild(providerLink);
+        }
+    }
+    appendStreamingText(delta) {
+        if (!this.panel) return;
+        const textElement = this.panel.querySelector('.summary-text');
+        if (!textElement) return;
+
+        if (!this._isStreaming) {
+            this._isStreaming = true;
+            this._streamBuffer = '';
+            textElement.replaceChildren();
+        }
+
+        this._streamBuffer += delta;
+
+        if (!this._renderTimer) {
+            this._renderTimer = setTimeout(() => {
+                this._renderStreamedMarkdown(textElement);
+                this._renderTimer = null;
+            }, 150);
+        }
+    }
+
+    _renderStreamedMarkdown(textElement) {
+        if (!this._streamBuffer) return;
+        try {
+            const html = marked.parse(this._streamBuffer);
+            const fragment = sanitizeHtmlToFragment(html);
+            enforceSafeLinks(fragment);
+            this.setElementContent(textElement, fragment);
+        } catch (_) {
+            textElement.textContent = this._streamBuffer;
+        }
+
+        const content = this.panel?.querySelector('.summary-panel-content');
+        if (content) {
+            content.scrollTop = content.scrollHeight;
+        }
+    }
+
+    finishStreaming() {
+        if (this._renderTimer) {
+            clearTimeout(this._renderTimer);
+            this._renderTimer = null;
+        }
+        this._isStreaming = false;
+        this._streamBuffer = '';
+    }
+
+    renderStreamingMetadata(container, metadata) {
+        const chip = document.createElement('span');
+        chip.className = 'summary-metadata-chip summary-metadata-chip-streaming';
+        chip.textContent = 'Streaming';
+        container.appendChild(chip);
+
+        if (metadata.provider) {
+            const sep = document.createElement('span');
+            sep.className = 'summary-metadata-separator summary-metadata-provider-separator';
+            sep.textContent = ' | ';
+            container.appendChild(sep);
+
+            const providerSpan = document.createElement('span');
+            providerSpan.className = 'summary-metadata-primary summary-metadata-provider';
+            providerSpan.textContent = metadata.provider;
+            container.appendChild(providerSpan);
         }
     }
 }

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -121,7 +121,7 @@
                                                     <li>Make sure Ollama is running to see the list of available models in the dropdown</li>
                                                     <li>Enable CORS for the extension:
                                                         <div class="mt-2 p-2 bg-gray-200 rounded font-mono text-xs dark:bg-gray-900 dark:text-white">
-                                                            <p class="mb-1">On Mac (run on terminal):</p>
+                                                            <p class="mb-1">On Mac / Linux (run in terminal):</p>
                                                             <code class="bg-gray-100 px-2 py-1 rounded block overflow-x-auto dark:bg-gray-800 dark:text-white">
                                                                 OLLAMA_ORIGINS="chrome-extension://*,moz-extension://*" ollama serve
                                                             </code>

--- a/src/entrypoints/options/options.js
+++ b/src/entrypoints/options/options.js
@@ -14,7 +14,7 @@ const OPTIONAL_HOST_PERMISSIONS = {
     anthropic: ['https://api.anthropic.com/*'],
     openrouter: ['https://openrouter.ai/*'],
     google: ['https://generativelanguage.googleapis.com/*'],
-    ollama: ['http://localhost:11434/*'],
+    ollama: [],
     'ollama-cloud': ['https://ollama.com/*'],
 };
 

--- a/src/entrypoints/options/options.js
+++ b/src/entrypoints/options/options.js
@@ -36,6 +36,9 @@ function getOllamaCardId(providerId) {
 }
 
 async function hasOptionalHostPermissions(origins) {
+    if (!origins || origins.length === 0) {
+        return true;
+    }
     if (!browser.permissions?.contains) {
         return true;
     }

--- a/src/entrypoints/options/options.js
+++ b/src/entrypoints/options/options.js
@@ -14,7 +14,7 @@ const OPTIONAL_HOST_PERMISSIONS = {
     anthropic: ['https://api.anthropic.com/*'],
     openrouter: ['https://openrouter.ai/*'],
     google: ['https://generativelanguage.googleapis.com/*'],
-    ollama: [],
+    ollama: ['http://localhost:11434/*'],
     'ollama-cloud': ['https://ollama.com/*'],
 };
 

--- a/src/entrypoints/options/options.js
+++ b/src/entrypoints/options/options.js
@@ -383,16 +383,15 @@ async function fetchOllamaModels() {
             }
         }
     } catch (error) {
-        // Ollama not running is expected - user may not have started it yet
-        // Only log at debug level to avoid noise
-        await Logger.debug('Could not fetch Ollama models (Ollama may not be running):', error.message);
-        // Handle error by adding a helpful status option
+        await Logger.debug('Could not fetch Ollama models:', error.message);
         const selectElement = document.getElementById('ollama-model');
-        selectElement.options.length = 0
+        selectElement.options.length = 0;
 
         const option = document.createElement('option');
         option.value = '';
-        option.textContent = 'Ollama not running';
+        option.textContent = error.message?.includes('403')
+            ? 'CORS blocked — see setup guide above'
+            : 'Ollama not running';
         selectElement.appendChild(option);
     }
 }

--- a/src/lib/llm-summarizer.js
+++ b/src/lib/llm-summarizer.js
@@ -1,4 +1,4 @@
-import {generateText} from 'ai';
+import {generateText, streamText} from 'ai';
 
 import {createOpenAI} from '@ai-sdk/openai';
 import {createAnthropic} from '@ai-sdk/anthropic';
@@ -6,54 +6,49 @@ import {createGoogleGenerativeAI} from '@ai-sdk/google';
 import {createOpenRouter} from '@openrouter/ai-sdk-provider';
 import {Logger} from "./utils.js";
 
+function createModel(aiProvider, modelId, apiKey) {
+    switch (aiProvider) {
+        case 'openai':
+            return createOpenAI({ apiKey })(modelId);
+
+        case 'anthropic':
+            return createAnthropic({
+                apiKey,
+                headers: { 'anthropic-dangerous-direct-browser-access': 'true' },
+            })(modelId);
+
+        case 'google':
+            return createGoogleGenerativeAI({ apiKey })(modelId);
+
+        case 'openrouter':
+            return createOpenRouter({ apiKey }).chat(modelId);
+
+        default:
+            throw new Error(`Unsupported AI provider: ${aiProvider}, model: ${modelId}`);
+    }
+}
+
+function improveError(error, data) {
+    const errorPrefix = `AI SDK API error. Reason: ${error.reason}. ` +
+        `AI Provider: ${data?.aiProvider}, Model: ${data?.modelId}`;
+    if (error instanceof Error) {
+        error.message = `${errorPrefix} Message: ${error.message}`;
+        return error;
+    }
+    return new Error(`${errorPrefix}. Message: ${String(error)}`);
+}
+
 export async function summarizeText(data) {
     try {
-
         const { aiProvider, modelId, apiKey, systemPrompt, userPrompt, parameters = {} } = data;
 
-        let model;
-        switch (aiProvider) {
-            // AI provider can be 'openai', 'anthropic', 'google' or 'openrouter'
-            case 'openai':
-                const openai = createOpenAI({
-                    apiKey: apiKey,
-                });
-                model = openai(modelId);
-                break;
-
-            case 'anthropic':
-                const anthropic = createAnthropic({
-                    apiKey: apiKey,
-                    headers: {
-                        'anthropic-dangerous-direct-browser-access': 'true',
-                    },
-                });
-                model = anthropic(modelId);
-                break;
-
-            case 'google':
-                const google = createGoogleGenerativeAI({
-                    apiKey: apiKey,
-                });
-                model = google(modelId);
-                break;
-
-            case 'openrouter':
-                const openRouter = createOpenRouter({
-                    apiKey: apiKey,
-                });
-                model = openRouter.chat(modelId);
-                break;
-
-            default:
-                throw new Error(`Unsupported AI provider: ${aiProvider}, model: ${modelId}`);
-        }
+        const model = createModel(aiProvider, modelId, apiKey);
         if (!model) {
             throw new Error(`Failed to initialize model for provider: ${aiProvider}, model: ${modelId}`);
         }
 
         const { text: summary } = await generateText({
-            model: model,
+            model,
             system: systemPrompt,
             prompt: userPrompt,
             temperature: parameters.temperature,
@@ -64,21 +59,48 @@ export async function summarizeText(data) {
         });
 
         await Logger.debug('Summarized text success. Summary:', summary);
-
         return summary;
 
     } catch (caughtError) {
-        const improveError = (error) => {
-            const errorPrefix = `AI SDK API generateText() threw error. Reason: ${error.reason}. ` +
-                `AI Provider: ${data?.aiProvider}, Model: ${data?.modelId}`;
-            if (error instanceof Error) {
-                error.message = `${errorPrefix} Message: ${error.message}`;
-                return  error;
-            }
-            return  new Error(`${errorPrefix}. Message: ${String(error)}`);
-        }
-        const error = improveError(caughtError);
+        const error = improveError(caughtError, data);
         await Logger.error(error);
         throw error;
+    }
+}
+
+export async function streamSummarizeText(data, onChunk, onDone, onError, abortSignal) {
+    try {
+        const { aiProvider, modelId, apiKey, systemPrompt, userPrompt, parameters = {} } = data;
+
+        const model = createModel(aiProvider, modelId, apiKey);
+        if (!model) {
+            throw new Error(`Failed to initialize model for provider: ${aiProvider}, model: ${modelId}`);
+        }
+
+        const result = streamText({
+            model,
+            system: systemPrompt,
+            prompt: userPrompt,
+            temperature: parameters.temperature,
+            topP: parameters.topP,
+            frequencyPenalty: parameters.frequencyPenalty,
+            presencePenalty: parameters.presencePenalty,
+            maxOutputTokens: parameters.maxOutputTokens,
+            abortSignal
+        });
+
+        for await (const delta of result.textStream) {
+            if (abortSignal?.aborted) break;
+            onChunk(delta);
+        }
+
+        const fullText = await result.text;
+        onDone(fullText);
+
+    } catch (caughtError) {
+        if (abortSignal?.aborted) return;
+        const error = improveError(caughtError, data);
+        await Logger.error(error);
+        onError(error);
     }
 }

--- a/src/lib/messaging.js
+++ b/src/lib/messaging.js
@@ -41,3 +41,38 @@ export async function sendBackgroundMessage(type, data) {
     responseData.duration = duration;
     return responseData;
 }
+
+export function sendStreamingMessage(type, data, onChunk) {
+    return new Promise((resolve, reject) => {
+        const startTime = performance.now();
+        const port = browser.runtime.connect({ name: 'HN_STREAM' });
+
+        port.onMessage.addListener((message) => {
+            switch (message.type) {
+                case 'chunk':
+                    onChunk(message.delta);
+                    break;
+                case 'done': {
+                    const duration = Math.round((performance.now() - startTime) / 1000);
+                    port.disconnect();
+                    resolve({ summary: message.text, duration });
+                    break;
+                }
+                case 'error': {
+                    port.disconnect();
+                    reject(new Error(message.error));
+                    break;
+                }
+            }
+        });
+
+        port.onDisconnect.addListener(() => {
+            const error = browser.runtime.lastError;
+            if (error) {
+                reject(new Error(error.message || 'Port disconnected'));
+            }
+        });
+
+        port.postMessage({ type, data });
+    });
+}

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -22,7 +22,6 @@ export default defineConfig({
                 "https://api.anthropic.com/*",
                 "https://openrouter.ai/*",
                 "https://generativelanguage.googleapis.com/*",
-                "http://localhost:11434/*",
                 "https://ollama.com/*"
             ],
             icons: {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
                 "https://api.anthropic.com/*",
                 "https://openrouter.ai/*",
                 "https://generativelanguage.googleapis.com/*",
+                "http://localhost:11434/*",
                 "https://ollama.com/*"
             ],
             icons: {


### PR DESCRIPTION
Hey George, Ann! 👋

This is a clean re-open of #25, rebased onto current `main` so the diff is **streaming-only** — now that #24 (Ollama Cloud) is merged, those changes are no longer mixed into this PR and it should be much easier to review.

This adds **streaming responses** for all cloud providers. Instead of staring at a spinner for 20-30 seconds, users now see the summary building up in real-time with proper markdown formatting — headers, bullets, bold text appear as the LLM generates them.

## How it works

The existing `sendMessage` → `generateText` pipeline was one-shot — wait for the full response, then render. This PR adds a parallel **port-based streaming pipeline**:

```
Content Script ←→ Background Worker ←→ LLM
    port.connect("HN_STREAM")
    ← chunk (text delta)
    ← chunk (text delta)
    ← ...
    ← done (full text)
```

During streaming, the accumulated text is re-parsed through `marked.parse()` every 150ms, so users see formatted markdown building up progressively. On completion, the final render adds comment backlinks.

## What streams

| Provider | Before | After |
|----------|--------|-------|
| OpenAI, Anthropic, Google, OpenRouter | Spinner → full summary | Progressive markdown |
| Ollama Cloud | Spinner → full summary | Progressive markdown (NDJSON) |
| Ollama Local | Single-shot | Unchanged (localhost, fast enough) |
| Cached summaries | Instant | Unchanged |

## Files changed

- **`llm-summarizer.js`** — Extracted `createModel()` helper, added `streamSummarizeText()` using `streamText()` from Vercel AI SDK with `AbortSignal` support
- **`messaging.js`** — Added `sendStreamingMessage()` using `chrome.runtime.connect()` ports
- **`background/index.js`** — Added `onConnect` listener for `HN_STREAM` port, handles both AI SDK streaming and Ollama NDJSON streaming
- **`ai-summarizer.js`** — `onChunk` parameter on `summarizeTextWithLLM()` and `summarizeUsingOllama()`, routes to streaming or single-shot path
- **`summary-panel.js`** — `appendStreamingText()` with throttled `marked.parse()` re-renders, `finishStreaming()` cleanup, streaming metadata chip
- **`hnenhancer.js`** — Wires up `onChunk` callback for cloud providers and Ollama Cloud
- **`styles.css`** — Streaming chip with pulse animation

## Tested

Puppeteer e2e with Ollama Cloud (`glm-5.1`):
- First formatted text appeared at **7s** (vs 25s+ before)
- Headers and bullets rendered progressively during streaming
- Final render at **27s** with all markdown formatting and backlinks
- "Streaming" chip with pulse animation visible during generation
- "Generated 18s | ollama/glm-5.1" metadata on completion

## Test plan

- [ ] Trigger summarization with any cloud provider — text should stream in with markdown formatting
- [ ] Verify "Streaming" chip appears with pulse animation during generation
- [ ] Verify final render has clickable comment backlinks
- [ ] Navigate away mid-stream — no errors in console
- [ ] Verify Ollama Local still works single-shot
- [ ] Verify cached summaries still load instantly

Excited about this one — the streaming UX makes the extension feel much snappier! Let me know what you think.
